### PR TITLE
feat: support @salesforce/messageChannel

### DIFF
--- a/packages/@lwc/jest-transformer/src/index.js
+++ b/packages/@lwc/jest-transformer/src/index.js
@@ -24,6 +24,7 @@ const contentAssetUrlScopedImport = require('./transforms/content-asset-url-scop
 const schemaScopedImport = require('./transforms/schema-scoped-import');
 const userScopedImport = require('./transforms/user-scoped-import');
 const clientScopedImport = require('./transforms/client-scoped-import');
+const messageChannelScopedImport = require('./transforms/message-channel-scoped-import');
 
 const BABEL_CONFIG = {
     sourceMaps: 'both',
@@ -39,6 +40,7 @@ const BABEL_CONFIG = {
         schemaScopedImport,
         userScopedImport,
         clientScopedImport,
+        messageChannelScopedImport
     ],
 };
 

--- a/packages/@lwc/jest-transformer/src/test/modules/example/messageChannel/__tests__/messageChannel.test.js
+++ b/packages/@lwc/jest-transformer/src/test/modules/example/messageChannel/__tests__/messageChannel.test.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { createElement } from 'lwc';
+import MessageChannel from 'example/messageChannel';
+
+jest.mock(
+    '@salesforce/messageChannel/myMockedChannel__c',
+    () => {
+        return { default: "my channel value from test" };
+    },
+    { virtual: true }
+);
+
+jest.mock(
+    '@salesforce/messageChannel/ns__anotherMockedChannel__c',
+    () => {
+        return { default: "another channel value from test" };
+    },
+    { virtual: true }
+);
+
+afterEach(() => {
+    while (document.body.firstChild) {
+        document.body.removeChild(document.body.firstChild);
+    }
+});
+
+describe('example-message-channel', () => {
+    describe('importing @salesforce/messageChannel', () => {
+        it('returns a value that resolves for the default import', () => {
+            const element = createElement('example-message-channel', { is: MessageChannel });
+            document.body.appendChild(element);
+            const channel = element.getMyMsgChannel();
+            expect(channel).not.toBeNull();
+            expect(channel).toBe("my channel value from test");
+        });
+
+        it('returns a value that resolves for a second imported message channel', () => {
+            const element = createElement('example-message-channel', { is: MessageChannel });
+            document.body.appendChild(element);
+            const channel = element.getAnotherMsgChannel();
+            expect(channel).not.toBeNull();
+            expect(channel).toBe("another channel value from test");
+        });
+
+        it('returns default message channel value as import path', () => {
+            const element = createElement('example-message-channel', { is: MessageChannel });
+            document.body.appendChild(element);
+            const channel = element.getUnmockedChannel();
+            expect(channel).not.toBeNull();
+            expect(channel).toBe("myUnmockedChannel__c");
+        });
+    });
+});

--- a/packages/@lwc/jest-transformer/src/test/modules/example/messageChannel/messageChannel.html
+++ b/packages/@lwc/jest-transformer/src/test/modules/example/messageChannel/messageChannel.html
@@ -1,0 +1,7 @@
+<!--
+Copyright (c) 2018, salesforce.com, inc.
+All rights reserved.
+SPDX-License-Identifier: MIT
+For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+-->
+<template></template>

--- a/packages/@lwc/jest-transformer/src/test/modules/example/messageChannel/messageChannel.js
+++ b/packages/@lwc/jest-transformer/src/test/modules/example/messageChannel/messageChannel.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { LightningElement, api } from 'lwc';
+
+import MY_MOCKED_CHANNEL from '@salesforce/messageChannel/myMockedChannel__c';
+import MY_UNMOCKED_CHANNEL from '@salesforce/messageChannel/myUnmockedChannel__c';
+import ANOTHER_MOCKED_CHANNEL from '@salesforce/messageChannel/ns__anotherMockedChannel__c';
+
+export default class MessageChannel extends LightningElement {
+    @api getMyMsgChannel() {
+        return MY_MOCKED_CHANNEL;
+    }
+
+    @api getUnmockedChannel() {
+        return MY_UNMOCKED_CHANNEL;
+    }
+
+    @api getAnotherMsgChannel() {
+        return ANOTHER_MOCKED_CHANNEL;
+    }
+}

--- a/packages/@lwc/jest-transformer/src/transforms/__tests__/message-channel-scoped-import.test.js
+++ b/packages/@lwc/jest-transformer/src/transforms/__tests__/message-channel-scoped-import.test.js
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+const test = require('./utils/test-transform').test(require('../message-channel-scoped-import'));
+
+describe('@salesforce/messageChannel import', () => {
+    test(
+        'does default transformation for values with __c suffix',
+        `
+        import myMessageChannel from '@salesforce/messageChannel/foo__c';
+    `,
+        `
+        let myMessageChannel;
+
+        try {
+          myMessageChannel = require("@salesforce/messageChannel/foo__c").default;
+        } catch (e) {
+          myMessageChannel = "foo__c";
+        }
+    `
+    );
+
+    test(
+        'does default transformation for namespaced values',
+        `
+        import myMessageChannel from '@salesforce/messageChannel/ns__foo';
+    `,
+        `
+        let myMessageChannel;
+
+        try {
+          myMessageChannel = require("@salesforce/messageChannel/ns__foo").default;
+        } catch (e) {
+          myMessageChannel = "ns__foo";
+        }
+    `
+    );
+
+    test(
+        'does default transformation for namespaced values with __c suffix',
+        `
+        import myMessageChannel from '@salesforce/messageChannel/ns__foo__c';
+    `,
+        `
+        let myMessageChannel;
+
+        try {
+          myMessageChannel = require("@salesforce/messageChannel/ns__foo__c").default;
+        } catch (e) {
+          myMessageChannel = "ns__foo__c";
+        }
+    `
+    );
+
+    test(
+        'allows non-@salesforce/messageChannel named imports',
+        `
+        import { otherNamed } from './something-valid';
+        import myMessageChannel from '@salesforce/messageChannel/foo__c';
+    `,
+        `
+        import { otherNamed } from './something-valid';
+        let myMessageChannel;
+
+        try {
+          myMessageChannel = require("@salesforce/messageChannel/foo__c").default;
+        } catch (e) {
+          myMessageChannel = "foo__c";
+        }
+    `
+    );
+
+    test(
+        'throws error if using named import',
+        `
+        import { myMessageChannel } from '@salesforce/messageChannel/foo__c';
+    `,
+        undefined,
+        'Invalid import from @salesforce/messageChannel/foo__c'
+    );
+
+    test(
+        'throws error if renamed default imports',
+        `
+        import { default as messageChannel } from '@salesforce/messageChannel/foo__c';
+    `,
+        undefined,
+        'Invalid import from @salesforce/messageChannel/foo__c'
+    );
+
+    test(
+        'throws error if renamed multiple default imports',
+        `
+        import { default as messageChannel, foo } from '@salesforce/messageChannel/foo__c';
+    `,
+        undefined,
+        'Invalid import from @salesforce/messageChannel/foo__c'
+    );
+});

--- a/packages/@lwc/jest-transformer/src/transforms/message-channel-scoped-import.js
+++ b/packages/@lwc/jest-transformer/src/transforms/message-channel-scoped-import.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+const { stringScopedImportTransform } = require('./utils');
+
+const MESSAGE_CHANNEL_IMPORT_IDENTIFIER = '@salesforce/messageChannel/';
+
+module.exports = function({ types: t }) {
+    return {
+        visitor: {
+            ImportDeclaration(path) {
+                if (path.get('source.value').node.startsWith(MESSAGE_CHANNEL_IMPORT_IDENTIFIER)) {
+                    stringScopedImportTransform(t, path, MESSAGE_CHANNEL_IMPORT_IDENTIFIER);
+                }
+            },
+        },
+    };
+};


### PR DESCRIPTION
Jest transformer support for the `@salesforce/messageChannel` import type.