### PR TITLE
Revert "refactor: starting lwc 1.1.x, jest tests will run native shad…

### DIFF
--- a/packages/@lwc/jest-preset/jest-preset.js
+++ b/packages/@lwc/jest-preset/jest-preset.js
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+const path = require('path');
+
 module.exports = {
     moduleFileExtensions: ['js', 'html'],
     moduleNameMapper: {
@@ -12,7 +14,7 @@ module.exports = {
         '^instrumentation-service$': require.resolve('./src/stubs/auraInstrumentation.js'),
         '^aura-storage$': require.resolve('./src/stubs/auraStorage.js'),
     },
-    testEnvironment: "jest-environment-jsdom-fifteen",
+    testEnvironment: path.resolve(__dirname, 'src/environment.js'),
     resolver: require.resolve('@lwc/jest-resolver'),
     transform: {
         '^.+\\.(js|html|css)$': require.resolve('@lwc/jest-transformer'),

--- a/packages/@lwc/jest-preset/src/environment.js
+++ b/packages/@lwc/jest-preset/src/environment.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+const fs = require('fs');
+const vm = require('vm');
+const JSDOMEnvironment = require('jest-environment-jsdom-fifteen');
+const polyfillFile = require.resolve('@lwc/synthetic-shadow');
+const polyfillSource = fs.readFileSync(polyfillFile, 'utf-8');
+const polyfillScript = vm.createScript(polyfillSource, '@lwc/synthetic-shadow');
+
+let ShadowRootPatched;
+let HTMLSlotElementPatched;
+/** Synthetic Shadow Polyfill should be installed only once per worker */
+function _syntheticShadow(env) {
+    if (env.dom) {
+        env.dom.runVMScript(polyfillScript);
+        // eslint-disable-next-line no-func-assign
+        _syntheticShadow = function _syntheticShadow() {
+            /* noop */
+        };
+        // Cache the patched types and reuse
+        ShadowRootPatched = env.dom.window.ShadowRoot;
+        HTMLSlotElementPatched = env.dom.window.HTMLSlotElement;
+    }
+}
+
+module.exports = class JSDOMEnvironmentWithSyntheticShadow extends JSDOMEnvironment {
+    constructor(config, options = {}) {
+        super(config, options);
+
+        // Running the synthetic-shadow polyfill
+        _syntheticShadow(this);
+
+        // Instrinsics that should be transferred to each environment
+        this.global.ShadowRoot = ShadowRootPatched;
+        this.global.HTMLSlotElement = HTMLSlotElementPatched;
+    }
+};


### PR DESCRIPTION
…ow (#17)"

This reverts commit d5a65fe372ca9682b375ae5bcd7d101e6a5cbb05.

It looks like this commit actually depends on LWC 1.1.x and is causing issues with 1.0. Reverting this commit for now and when LWC version 1.1.x is officially released we will add this back along with the LWC version peer dependency upgrade. 