### PR TITLE
Add support for LWC modules from npm packages in lwc 1.1

### DIFF
--- a/packages/@lwc/jest-resolver/src/index.js
+++ b/packages/@lwc/jest-resolver/src/index.js
@@ -31,7 +31,13 @@ const WHITELISTED_LWC_PACKAGES = {
     'wire-service': '@lwc/wire-service',
     'wire-service-jest-util': 'lwc-wire-service-jest-util',
 };
-const lwcMap = lwcNpmResolver.resolveLwcNpmModules();
+const pkgJson = JSON.parse(fs.readFileSync(`package.json`, 'utf8'));
+
+let lwcMap = lwcNpmResolver.resolveModules({
+    modules: [...Object.keys(pkgJson.dependencies)],
+});
+
+lwcMap = lwcMap.reduce((map, m) => ((map[m.specifier] = m), map), {});
 
 // This logic is somewhat the same in the compiler resolution system
 // We should try to consolidate it at some point.


### PR DESCRIPTION
The current module resolution doesn't take into account modules that are imported via NPM.

As they need to be passed explicitly the dependencies of the current project are passed to the module resolver, similar as with `create-lwc-app`.

FYI @diervo 