### PR TITLE
refactor(serializer): replace attributes with placeholders instead of removing

### DIFF
--- a/packages/@lwc/jest-serializer/src/__tests__/__snapshots__/clean-element-attrs.spec.js.snap
+++ b/packages/@lwc/jest-serializer/src/__tests__/__snapshots__/clean-element-attrs.spec.js.snap
@@ -1,51 +1,84 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`clean element attributes should remove all id-referencing aria attributes 1`] = `
+exports[`serialized element attributes should remove the lwc:host attribute 1`] = `
 <div>
    
   <div>
+    12345
+  </div>
+   
+  <div>
+    abcde
+  </div>
+   
+</div>
+`;
+
+exports[`serialized element attributes should replace all id-referencing aria attributes with placeholders 1`] = `
+<div>
+   
+  <div
+    aria-activedescendant="[shadow:guid]"
+  >
     aria-activedescendant
   </div>
    
-  <div>
+  <div
+    aria-controls="[shadow:guid]"
+  >
     aria-controls
   </div>
    
-  <div>
+  <div
+    aria-describedby="[shadow:guid]"
+  >
     aria-describedby
   </div>
    
-  <div>
+  <div
+    aria-details="[shadow:guid]"
+  >
     aria-details
   </div>
    
-  <div>
+  <div
+    aria-errormessage="[shadow:guid]"
+  >
     aria-errormessage
   </div>
    
-  <div>
+  <div
+    aria-flowto="[shadow:guid]"
+  >
     aria-flowto
   </div>
    
-  <div>
+  <div
+    aria-labelledby="[shadow:guid]"
+  >
     aria-labelledby
   </div>
    
-  <div>
+  <div
+    aria-owns="[shadow:guid]"
+  >
     aria-owns
   </div>
    
 </div>
 `;
 
-exports[`clean element attributes should remove both id and for attributes 1`] = `
+exports[`serialized element attributes should replace both id and for attributes with placeholders 1`] = `
 <div>
    
-  <label>
+  <label
+    for="[shadow:guid]"
+  >
     Do you like cheese?
   </label>
    
   <input
+    id="[shadow:guid]"
     name="cheese"
     type="checkbox"
   />
@@ -53,7 +86,7 @@ exports[`clean element attributes should remove both id and for attributes 1`] =
 </div>
 `;
 
-exports[`clean element attributes should remove the href and xlink:href attributes if it is a fragment id for svg use tags 1`] = `
+exports[`serialized element attributes should replace the href and xlink:href attributes with placeholders if it is a fragment id for svg use tags 1`] = `
 <div>
    
   <svg
@@ -68,6 +101,7 @@ exports[`clean element attributes should remove the href and xlink:href attribut
         cx="10"
         cy="10"
         fill="black"
+        id="[shadow:guid]"
         r="10"
       />
        
@@ -75,24 +109,31 @@ exports[`clean element attributes should remove the href and xlink:href attribut
         cx="14"
         cy="14"
         fill="red"
+        id="[shadow:guid]"
         r="10"
       />
        
     </defs>
      
-    <use />
+    <use
+      href="[shadow:fragment-id]"
+    />
      
-    <use />
+    <use
+      xlink:href="[shadow:fragment-id]"
+    />
      
   </svg>
    
 </div>
 `;
 
-exports[`clean element attributes should remove the href attribute if it is a fragment id for anchor tags 1`] = `
+exports[`serialized element attributes should replace the href attribute with a placeholder if it is a fragment id for anchor tags 1`] = `
 <div>
    
-  <a>
+  <a
+    href="[shadow:fragment-id]"
+  >
     ny state of mind
   </a>
    
@@ -105,36 +146,26 @@ exports[`clean element attributes should remove the href attribute if it is a fr
 </div>
 `;
 
-exports[`clean element attributes should remove the href attribute if it is a fragment id for area tags 1`] = `
+exports[`serialized element attributes should replace the href attribute with a placeholder if it is a fragment id for area tags 1`] = `
 <div>
    
   <map
     name="kyoto"
   >
      
-    <area />
+    <area
+      href="[shadow:fragment-id]"
+    />
      
-    <area />
+    <area
+      href="[shadow:fragment-id]"
+    />
      
     <area
       href="https://duckduckgo.com/?q=kyoto"
     />
      
   </map>
-   
-</div>
-`;
-
-exports[`clean element attributes should remove the lwc:host attribute 1`] = `
-<div>
-   
-  <div>
-    12345
-  </div>
-   
-  <div>
-    abcde
-  </div>
    
 </div>
 `;

--- a/packages/@lwc/jest-serializer/src/__tests__/__snapshots__/clean-element-attrs.spec.js.snap
+++ b/packages/@lwc/jest-serializer/src/__tests__/__snapshots__/clean-element-attrs.spec.js.snap
@@ -116,11 +116,11 @@ exports[`serialized element attributes should replace the href and xlink:href at
     </defs>
      
     <use
-      href="[shadow:fragment-id]"
+      href="#[shadow:guid]"
     />
      
     <use
-      xlink:href="[shadow:fragment-id]"
+      xlink:href="#[shadow:guid]"
     />
      
   </svg>
@@ -132,7 +132,7 @@ exports[`serialized element attributes should replace the href attribute with a 
 <div>
    
   <a
-    href="[shadow:fragment-id]"
+    href="#[shadow:guid]"
   >
     ny state of mind
   </a>
@@ -154,11 +154,11 @@ exports[`serialized element attributes should replace the href attribute with a 
   >
      
     <area
-      href="[shadow:fragment-id]"
+      href="#[shadow:guid]"
     />
      
     <area
-      href="[shadow:fragment-id]"
+      href="#[shadow:guid]"
     />
      
     <area

--- a/packages/@lwc/jest-serializer/src/__tests__/clean-element-attrs.spec.js
+++ b/packages/@lwc/jest-serializer/src/__tests__/clean-element-attrs.spec.js
@@ -1,5 +1,5 @@
-describe('clean element attributes', () => {
-    it('should remove both id and for attributes', () => {
+describe('serialized element attributes', () => {
+    it('should replace both id and for attributes with placeholders', () => {
         const elm = document.createElement('div');
         elm.innerHTML = `
             <label for="cheese">Do you like cheese?</label>
@@ -8,7 +8,7 @@ describe('clean element attributes', () => {
         expect(elm).toMatchSnapshot();
     });
 
-    it('should remove all id-referencing aria attributes', () => {
+    it('should replace all id-referencing aria attributes with placeholders', () => {
         const elm = document.createElement('div');
         elm.innerHTML = `
             <div aria-activedescendant="aria-activedescendant">aria-activedescendant</div>
@@ -32,7 +32,7 @@ describe('clean element attributes', () => {
         expect(elm).toMatchSnapshot();
     });
 
-    it('should remove the href attribute if it is a fragment id for anchor tags', () => {
+    it('should replace the href attribute with a placeholder if it is a fragment id for anchor tags', () => {
         const elm = document.createElement('div');
         elm.innerHTML = `
             <a href="#ny-state-of-mind">ny state of mind</a>
@@ -41,7 +41,7 @@ describe('clean element attributes', () => {
         expect(elm).toMatchSnapshot();
     });
 
-    it('should remove the href attribute if it is a fragment id for area tags', () => {
+    it('should replace the href attribute with a placeholder if it is a fragment id for area tags', () => {
         const elm = document.createElement('div');
         elm.innerHTML = `
             <map name="kyoto">
@@ -53,7 +53,7 @@ describe('clean element attributes', () => {
         expect(elm).toMatchSnapshot();
     });
 
-    it('should remove the href and xlink:href attributes if it is a fragment id for svg use tags', () => {
+    it('should replace the href and xlink:href attributes with placeholders if it is a fragment id for svg use tags', () => {
         const elm = document.createElement('div');
         elm.innerHTML = `
             <svg width="100px" height="100px" viewport="0 0 100 100">

--- a/packages/@lwc/jest-serializer/src/clean-element-attrs.js
+++ b/packages/@lwc/jest-serializer/src/clean-element-attrs.js
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+const FRAG_ID_ATTR_VALUE = '[shadow:fragment-id]';
+const GUID_ATTR_VALUE = '[shadow:guid]';
 
 // https://github.com/salesforce/lwc/blob/48e546f1d75a92ddc54febff6cecb89c3a2aafde/packages/%40lwc/template-compiler/src/parser/constants.ts#L29-L39
 const ID_REFERENCING_ATTRIBUTES_SET = [
@@ -19,13 +21,16 @@ const ID_REFERENCING_ATTRIBUTES_SET = [
 ];
 
 const ATTRS_TO_REMOVE = [
-    ...ID_REFERENCING_ATTRIBUTES_SET,
-    'id',
     'lwc:host', // https://github.com/salesforce/lwc/pull/1600
 ];
 
+const MANGLED_ATTRS = [
+    ...ID_REFERENCING_ATTRIBUTES_SET,
+    'id',
+];
+
 // Attributes that can use fragment id values
-const FRAG_ID_ATTRS_TO_REMOVE = [
+const FRAG_ID_ATTRS = [
     'href',
     'xlink:href',
 ];
@@ -41,13 +46,18 @@ function cleanElementAttributes(elm) {
     // The `use` element's tagName value is lowercase!
     const tagName = elm.tagName.toLowerCase();
     if (FRAG_ID_TAG_NAME_SET.has(tagName)) {
-        FRAG_ID_ATTRS_TO_REMOVE.forEach(name => {
+        FRAG_ID_ATTRS.forEach(name => {
             const value = elm.getAttribute(name);
             if (/^#/.test(value)) {
-                elm.removeAttribute(name);
+                elm.setAttribute(name, FRAG_ID_ATTR_VALUE);
             }
         });
     }
+    MANGLED_ATTRS.forEach(name => {
+        if (elm.hasAttribute(name)) {
+            elm.setAttribute(name, GUID_ATTR_VALUE);
+        }
+    });
     ATTRS_TO_REMOVE.forEach(name => {
         elm.removeAttribute(name);
     });

--- a/packages/@lwc/jest-serializer/src/clean-element-attrs.js
+++ b/packages/@lwc/jest-serializer/src/clean-element-attrs.js
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-const FRAG_ID_ATTR_VALUE = '[shadow:fragment-id]';
 const GUID_ATTR_VALUE = '[shadow:guid]';
+const FRAG_ID_ATTR_VALUE = `#${GUID_ATTR_VALUE}`;
 
 // https://github.com/salesforce/lwc/blob/48e546f1d75a92ddc54febff6cecb89c3a2aafde/packages/%40lwc/template-compiler/src/parser/constants.ts#L29-L39
 const ID_REFERENCING_ATTRIBUTES_SET = [


### PR DESCRIPTION
Removing attributes completely is likely to cause confusion so it's better to leave a placeholder that indicates that we are doing something there.