### PR TITLE
build: remove peer dependencies (for now)

### DIFF
--- a/packages/@lwc/jest-preset/package.json
+++ b/packages/@lwc/jest-preset/package.json
@@ -13,8 +13,7 @@
     ],
     "main": "jest-preset.js",
     "peerDependencies": {
-        "jest": ">=24.9.0",
-        "lwc": "*"
+        "jest": ">=24.9.0"
     },
     "dependencies": {
         "@lwc/jest-resolver": "4.1.0-224.1",

--- a/packages/@lwc/jest-transformer/package.json
+++ b/packages/@lwc/jest-transformer/package.json
@@ -21,9 +21,7 @@
         "babel-preset-jest": "^24.0.0"
     },
     "peerDependencies": {
-        "@lwc/compiler": "*",
-        "jest": ">= 24.0.0",
-        "lwc": "*"
+        "jest": ">= 24.0.0"
     },
     "devDependencies": {
         "@lwc/jest-preset": "4.1.0-224.1",


### PR DESCRIPTION
Users currently have two ways of consuming the @lwc packages distributed by the lwc dist package so having peer dependencies causes issues. Removing them for now until we have a better story around managing dependencies.