### PR TITLE
fix: support dynamic imports in jest tests

### DIFF
--- a/packages/@lwc/jest-transformer/src/index.js
+++ b/packages/@lwc/jest-transformer/src/index.js
@@ -60,6 +60,9 @@ module.exports = {
             outputConfig: {
                 sourcemap: true,
             },
+            experimentalDynamicComponent: {
+                strictSpecifier: false
+            }
         });
 
         // if is not .js, we add the .compiled extension in the sourcemap

--- a/packages/@lwc/jest-transformer/src/test/modules/example/dynamicImport/__tests__/__snapshots__/dynamicImport.test.js.snap
+++ b/packages/@lwc/jest-transformer/src/test/modules/example/dynamicImport/__tests__/__snapshots__/dynamicImport.test.js.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`dynamic-imports should render correct snapshot 1`] = `
+<example-dynamic-import>
+  #shadow-root(open)
+    <x-lazy>
+      #shadow-root(open)
+        <p>
+          example-foo
+        </p>
+        <div
+          class="fooClass"
+        >
+          Hi from 
+          foo
+        </div>
+        <example-foo-inner>
+          #shadow-root(open)
+            <p
+              class="exampleFooInner"
+            >
+              example-foo-inner
+            </p>
+            <slot />
+          <div>
+            Passed Element
+          </div>
+        </example-foo-inner>
+        <other-bar>
+          #shadow-root(open)
+            <p
+              class="otherBar"
+            >
+              other-bar
+            </p>
+        </other-bar>
+    </x-lazy>
+</example-dynamic-import>
+`;

--- a/packages/@lwc/jest-transformer/src/test/modules/example/dynamicImport/__tests__/__snapshots__/dynamicImport.test.js.snap
+++ b/packages/@lwc/jest-transformer/src/test/modules/example/dynamicImport/__tests__/__snapshots__/dynamicImport.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`dynamic-imports should render correct snapshot 1`] = `
+exports[`dynamic-imports should render dynamically imported component 1`] = `
 <example-dynamic-import>
   #shadow-root(open)
     <x-lazy>

--- a/packages/@lwc/jest-transformer/src/test/modules/example/dynamicImport/__tests__/dynamicImport.test.js
+++ b/packages/@lwc/jest-transformer/src/test/modules/example/dynamicImport/__tests__/dynamicImport.test.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { createElement } from 'lwc';
+import DynamicImport from 'example/dynamicImport';
+
+
+describe('dynamic-imports', () => {
+    it('should render dynamically imported component', () => {
+        const element = createElement('example-dynamic-import', { is: DynamicImport });
+        document.body.appendChild(element);
+
+        return Promise.resolve()
+            .then(() => Promise.resolve())
+            .then(() => {
+                expect(element).toMatchSnapshot();
+            });
+    });
+});

--- a/packages/@lwc/jest-transformer/src/test/modules/example/dynamicImport/dynamicImport.html
+++ b/packages/@lwc/jest-transformer/src/test/modules/example/dynamicImport/dynamicImport.html
@@ -1,0 +1,3 @@
+<template>
+    <x-lazy lwc:dynamic={ctor}></x-lazy>
+</template>

--- a/packages/@lwc/jest-transformer/src/test/modules/example/dynamicImport/dynamicImport.js
+++ b/packages/@lwc/jest-transformer/src/test/modules/example/dynamicImport/dynamicImport.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { LightningElement } from 'lwc';
+
+export default class DynamicImport extends LightningElement {
+    ctor = null;
+
+    connectedCallback() {
+        this.loadCtor();
+    }
+
+    async loadCtor() {
+        const moduleName = 'example/foo';
+        const module = await import(moduleName);
+
+        this.ctor = module.default;
+    }
+}


### PR DESCRIPTION
[babelDynamicImport](https://github.com/salesforce/lwc-test/blob/master/packages/%40lwc/jest-transformer/src/index.js#L37) will take care of correctly transform the import. But the default option of the lwc compiler is `strictSpecifier: true`, making invalid the import syntax when used with an identifier.

This PR lift that restriction on jest environments.