### PR TITLE
fix for correct import of instrumentation/service

### DIFF
--- a/packages/@lwc/jest-preset/jest-preset.js
+++ b/packages/@lwc/jest-preset/jest-preset.js
@@ -9,7 +9,7 @@ module.exports = {
     moduleNameMapper: {
         '^aura$': require.resolve('./src/stubs/aura.js'),
         '^aura-instrumentation$': require.resolve('./src/stubs/auraInstrumentation.js'),
-        '^instrumentation-service$': require.resolve('./src/stubs/auraInstrumentation.js'),
+        '^instrumentation/service$': require.resolve('./src/stubs/auraInstrumentation.js'),
         '^aura-storage$': require.resolve('./src/stubs/auraStorage.js'),
     },
     resolver: require.resolve('@lwc/jest-resolver'),

--- a/packages/@lwc/jest-preset/src/stubs/__tests__/instrumentationServiceStub.test.js
+++ b/packages/@lwc/jest-preset/src/stubs/__tests__/instrumentationServiceStub.test.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+// use import like consuming components will, and point to generated file in `dist` folder
+// via jest config
+
+import { perfStart } from 'instrumentation/service';
+
+describe('instrumentationServiceStub.js', () => {
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+
+    // all functions are the same implementation so just test one
+    describe('perfStart', () => {
+        it('is an inspectable mock', () => {
+            perfStart('foo');
+            expect(perfStart).toBeCalledWith('foo');
+        });
+
+        it('can be called multiple times', () => {
+            perfStart('foo');
+            perfStart('bar');
+            expect(perfStart).toBeCalledWith('bar');
+        });
+
+        it('can have behavior overridden', () => {
+            perfStart.mockImplementation(() => 'mock return');
+            expect(perfStart()).toBe('mock return');
+        });
+
+        it('can override behavior multiple times in same test', () => {
+            perfStart.mockImplementation(() => 'mock return again');
+            expect(perfStart()).toBe('mock return again');
+        });
+    });
+});


### PR DESCRIPTION
Clients use the instrumentation service via:
`import * as metricsService from "instrumentation/service";`
The existing moduleNameMapper failed to resolve this import and mock the service. 

Testing using the existing moduleNameMapper fails to resolve the stub:

>  FAIL  __tests__/instrumentation.test.js
>  ● Test suite failed to run
>
>    Cannot find module 'instrumentation/service' from 'instrumentation.js'
>
>       5 |  */
>       6 | 
>       7 | import * as metricsService from "instrumentation/service";

A check of core found no relevant uses of the existing moduleNameMapper:
`~/blt/app/main/core$ grep -R instrumentation-service *

......./InstrumentationServiceImpl.java:            brave.Span childSpan = zipkinTracer.nextSpan().name("instrumentation-service");
~/blt/app/main/core$`

However, there are many uses of **instrumentation/service**.

Corrected the moduleNameMapper to use '/' instead of '-' and added a test.