### PR TITLE
fix(jest-preset): registerDecorators proxy does not returns original call result

### DIFF
--- a/packages/@lwc/jest-preset/src/__tests__/componentWithMixin.spec.js
+++ b/packages/@lwc/jest-preset/src/__tests__/componentWithMixin.spec.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { createElement } from 'lwc';
+import ComponentWithMixin from 'example/componentWithMixin';
+
+afterEach(() => {
+    while (document.body.firstChild) {
+        document.body.removeChild(document.body.firstChild);
+    }
+});
+
+describe('example-component-with-mixin', () => {
+    it('should render the component using mixin api attribute', () => {
+        const element = createElement('example-component-with-mixin', { is: ComponentWithMixin });
+        element.txt = 'test value';
+        document.body.appendChild(element);
+
+        return Promise.resolve().then(() => {
+            const paragraphWithText = element.shadowRoot.querySelector('.result-text');
+            expect(paragraphWithText.textContent).toBe('test value');
+        })
+    });
+});

--- a/packages/@lwc/jest-preset/src/setup.js
+++ b/packages/@lwc/jest-preset/src/setup.js
@@ -149,7 +149,7 @@ function overriddenRegisterDecorators(Ctor, decoratorsMeta) {
         wire[adapterName].adapter = wireAdapterMock;
     });
 
-    originalRegisterDecorators(Ctor, decoratorsMeta);
+    return originalRegisterDecorators(Ctor, decoratorsMeta);
 }
 
 function installRegisterDecoratorsTrap(lwc) {

--- a/packages/@lwc/jest-preset/src/test/modules/example/componentWithMixin/componentWithMixin.html
+++ b/packages/@lwc/jest-preset/src/test/modules/example/componentWithMixin/componentWithMixin.html
@@ -1,0 +1,9 @@
+<!--
+Copyright (c) 2018, salesforce.com, inc.
+All rights reserved.
+SPDX-License-Identifier: MIT
+For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+-->
+<template>
+    <p class="result-text">{txt}</p>
+</template>

--- a/packages/@lwc/jest-preset/src/test/modules/example/componentWithMixin/componentWithMixin.js
+++ b/packages/@lwc/jest-preset/src/test/modules/example/componentWithMixin/componentWithMixin.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { LightningElement, api } from 'lwc';
+
+function getSimpleMixin(BaseClass) {
+    return class extends BaseClass {
+        @api txt;
+    }
+}
+
+export default class ComponentWithMixin extends getSimpleMixin(LightningElement) {}

--- a/packages/@lwc/jest-preset/src/test/modules/example/wiredComponent/wiredComponent.js
+++ b/packages/@lwc/jest-preset/src/test/modules/example/wiredComponent/wiredComponent.js
@@ -7,13 +7,7 @@
 import { LightningElement, api, wire } from 'lwc';
 import { realAdapter } from 'example/adapter';
 
-function getNavigationMixin(BaseClass) {
-    return class extends BaseClass {
-        @api foo;
-    }
-}
-
-export default class WiredComponent extends getNavigationMixin(LightningElement) {
+export default class WiredComponent extends LightningElement {
     @api txt;
 
     wiredText;

--- a/packages/@lwc/jest-preset/src/test/modules/example/wiredComponent/wiredComponent.js
+++ b/packages/@lwc/jest-preset/src/test/modules/example/wiredComponent/wiredComponent.js
@@ -7,7 +7,13 @@
 import { LightningElement, api, wire } from 'lwc';
 import { realAdapter } from 'example/adapter';
 
-export default class WiredComponent extends LightningElement {
+function getNavigationMixin(BaseClass) {
+    return class extends BaseClass {
+        @api foo;
+    }
+}
+
+export default class WiredComponent extends getNavigationMixin(LightningElement) {
     @api txt;
 
     wiredText;


### PR DESCRIPTION
Fixes an issue with the `registerDecorator` proxy, that does not returns the result from calling the original `lwc.registerDecorator`