### PR TITLE
fix(jest-resolver): remap wire-service-jest-util to @salesforc/wire-s…

### DIFF
--- a/packages/@lwc/jest-resolver/src/index.js
+++ b/packages/@lwc/jest-resolver/src/index.js
@@ -28,7 +28,7 @@ const EMPTY_HTML_MOCK = resolve(__dirname, '..', 'resources', 'emptyHtmlMock.js'
 const WHITELISTED_LWC_PACKAGES = {
     lwc: '@lwc/engine',
     'wire-service': '@lwc/wire-service',
-    'wire-service-jest-util': 'lwc-wire-service-jest-util',
+    'wire-service-jest-util': '@salesforce/wire-service-jest-util',
 };
 
 // This logic is somewhat the same in the compiler resolution system


### PR DESCRIPTION
…ervice-jest-util

### Details

In a test file, imports from `wire-service-jest-util` are resolved to module `lwc-wire-service-jest-util`. Module `lwc-wire-service-jest-util` was removed in favor of `@salesforce/wire-service-jest-util`.

This PR changes that resolution to `@salesforce/wire-service-jest-util`.

