### PR TITLE
fix: ignore babelrc for typescript

### DIFF
--- a/packages/@lwc/jest-transformer/src/index.js
+++ b/packages/@lwc/jest-transformer/src/index.js
@@ -34,6 +34,8 @@ const accessCheck = require('./transforms/access-check-scoped-import');
 
 const BABEL_TS_CONFIG = {
     sourceMaps: 'inline',
+    babelrc: false,
+    configFile: false,
     plugins: [
         babelClassProperties,
         [


### PR DESCRIPTION
Fixes potential conflict with babel configs upstream