### PR TITLE
chore: relax jest peer dependency

### DIFF
--- a/packages/@lwc/jest-preset/package.json
+++ b/packages/@lwc/jest-preset/package.json
@@ -24,7 +24,7 @@
     "peerDependencies": {
         "@lwc/compiler": "*",
         "@lwc/synthetic-shadow": "*",
-        "jest": "^25.5.4"
+        "jest": ">=25.5.4"
     },
     "dependencies": {
         "@lwc/jest-resolver": "8.0.0",

--- a/packages/@lwc/jest-resolver/package.json
+++ b/packages/@lwc/jest-resolver/package.json
@@ -27,7 +27,7 @@
         "@lwc/jest-preset": "8.0.0"
     },
     "peerDependencies": {
-        "jest": "^25.5.4"
+        "jest": ">=25.5.4"
     },
     "license": "MIT",
     "engines": {

--- a/packages/@lwc/jest-serializer/package.json
+++ b/packages/@lwc/jest-serializer/package.json
@@ -24,7 +24,7 @@
         "pretty-format": "~25.4.0"
     },
     "peerDependencies": {
-        "jest": "^25.5.4"
+        "jest": ">=25.5.4"
     },
     "engines": {
         "node": ">=10"

--- a/packages/@lwc/jest-transformer/package.json
+++ b/packages/@lwc/jest-transformer/package.json
@@ -33,7 +33,7 @@
     },
     "peerDependencies": {
         "@lwc/compiler": "*",
-        "jest": "^25.5.4"
+        "jest": ">=25.5.4"
     },
     "devDependencies": {
         "@lwc/jest-preset": "8.0.0",


### PR DESCRIPTION
We still need to make sure that `jest` is at least v25.5.4 to avoid the `@jest/globals` issue.