### PR TITLE
chore: Remove wdio eslint artifact

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,8 +3,3 @@ node_modules/
 dist/
 lib/
 coverage/
-
-fixtures/
-public/
-
-wdio-lwc-service/


### PR DESCRIPTION
## Details
- Removes non-existant directories from `.eslintignore`.