### PR TITLE
chore: cleanup testURL

### DIFF
--- a/packages/@lwc/jest-preset/jest-preset.js
+++ b/packages/@lwc/jest-preset/jest-preset.js
@@ -13,8 +13,5 @@ module.exports = {
     setupFilesAfterEnv: [require.resolve('./src/setup.js')],
     snapshotSerializers: [require.resolve('@lwc/jest-serializer')],
     testMatch: ['**/__tests__/**/?(*.)(spec|test).(js|ts)'],
-
-    // temp workaround until this is released - https://github.com/facebook/jest/pull/6792
-    testURL: 'http://localhost/',
     coveragePathIgnorePatterns: ['.css$', '.html$'],
 };


### PR DESCRIPTION
Remove `testURL` from `jest.preset.js`. This has been merged with Jest 25.