### PR TITLE
fix: add @lwc/engine as peerDependency of @lwc/jest-preset

### DIFF
--- a/packages/@lwc/jest-preset/package.json
+++ b/packages/@lwc/jest-preset/package.json
@@ -22,6 +22,7 @@
     ],
     "peerDependencies": {
         "@lwc/compiler": "*",
+        "@lwc/engine": "*",
         "@lwc/synthetic-shadow": "*",
         "jest": "^26"
     },


### PR DESCRIPTION
`@lwc/engine` is not marked as a peer dependency of `@lwc/jest-preset`. However, `@lwc/engine` is required during the [environment setup](https://github.com/salesforce/lwc-test/blob/master/packages/%40lwc/jest-preset/src/setup.js#L149).