### PR TITLE
fix: update dep versions

### DIFF
--- a/packages/@lwc/jest-preset/package.json
+++ b/packages/@lwc/jest-preset/package.json
@@ -27,9 +27,9 @@
         "jest": "^26"
     },
     "dependencies": {
-        "@lwc/jest-resolver": "10.0.2",
-        "@lwc/jest-serializer": "10.0.2",
-        "@lwc/jest-transformer": "10.0.2"
+        "@lwc/jest-resolver": "11.0.0",
+        "@lwc/jest-serializer": "11.0.0",
+        "@lwc/jest-transformer": "11.0.0"
     },
     "engines": {
         "node": ">=10"

--- a/test/package.json
+++ b/test/package.json
@@ -4,8 +4,5 @@
     "private": "true",
     "scripts": {
         "test": "jest"
-    },
-    "devDependencies": {
-        "@lwc/jest-preset": "10.0.2"
     }
 }


### PR DESCRIPTION
I made a mistake during the v11.0.0 update, so I skipped some dependency versions, causing tests to fail.