### PR TITLE
docs: remove release steps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,3 @@ Any code change should be submitted as a pull request. The description should ex
 ## Review process
 
 The bigger the pull request, the longer it will take to review and merge. Try to break down large pull requests in smaller chunks that are easier to review and merge. Also make sure to reference the related issues in the pull request message, if any.
-
-## Publishing a new release
-
-Checkout the latest `master` branch of the repo. Run `yarn release <version> <npm-tag>` command by providing the appropriate arguments to publish a new release of the package. A release commit should have been automatically created on your local branch. Push the release commit and the git tag to the remote repo.


### PR DESCRIPTION
These release steps are incorrect (`yarn release` does not work), and I'm putting the full release steps in another document anyway: https://salesforce.quip.com/5tk3Ab98Dl8B