### PR TITLE
feat(jest-transformer): transform apex methods to a valid wire adapter

### DIFF
--- a/packages/@lwc/jest-transformer/src/transforms/__tests__/apex-continuation-scoped-import.test.js
+++ b/packages/@lwc/jest-transformer/src/transforms/__tests__/apex-continuation-scoped-import.test.js
@@ -17,12 +17,21 @@ describe('@salesforce/apexContinuation import', () => {
 
         try {
           myMethod = require("@salesforce/apexContinuation/FooController.fooMethod").default;
-        } catch (e) {
-          global.__lwcJestMock_myMethod = global.__lwcJestMock_myMethod || function myMethod() {
-            return Promise.resolve();
-          };
-
-          myMethod = global.__lwcJestMock_myMethod;
+        } catch (importSourceNotDefined) {
+          try {
+            const {
+              createApexTestWireAdapter
+            } = require('@salesforce/wire-service-jest-util');
+        
+            global.__lwcJestMock_myMethod = global.__lwcJestMock_myMethod || createApexTestWireAdapter(jest.fn().mockImplementation(() => Promise.resolve()));
+            myMethod = global.__lwcJestMock_myMethod;
+          } catch (wireServiceJestUtilNotDefined) {
+            global.__lwcJestMock_myMethod = global.__lwcJestMock_myMethod || function myMethod() {
+              return Promise.resolve();
+            };
+        
+            myMethod = global.__lwcJestMock_myMethod;
+          }
         }
     `
     );
@@ -39,12 +48,21 @@ describe('@salesforce/apexContinuation import', () => {
 
         try {
           myMethod = require("@salesforce/apexContinuation/FooController.fooMethod").default;
-        } catch (e) {
-          global.__lwcJestMock_myMethod = global.__lwcJestMock_myMethod || function myMethod() {
-            return Promise.resolve();
-          };
-
-          myMethod = global.__lwcJestMock_myMethod;
+        } catch (importSourceNotDefined) {
+          try {
+            const {
+              createApexTestWireAdapter
+            } = require('@salesforce/wire-service-jest-util');
+        
+            global.__lwcJestMock_myMethod = global.__lwcJestMock_myMethod || createApexTestWireAdapter(jest.fn().mockImplementation(() => Promise.resolve()));
+            myMethod = global.__lwcJestMock_myMethod;
+          } catch (wireServiceJestUtilNotDefined) {
+            global.__lwcJestMock_myMethod = global.__lwcJestMock_myMethod || function myMethod() {
+              return Promise.resolve();
+            };
+        
+            myMethod = global.__lwcJestMock_myMethod;
+          }
         }
     `
     );

--- a/packages/@lwc/jest-transformer/src/transforms/__tests__/apex-continuation-scoped-import.test.js
+++ b/packages/@lwc/jest-transformer/src/transforms/__tests__/apex-continuation-scoped-import.test.js
@@ -18,20 +18,21 @@ describe('@salesforce/apexContinuation import', () => {
         try {
           myMethod = require("@salesforce/apexContinuation/FooController.fooMethod").default;
         } catch (importSourceNotDefined) {
+          global._apexMethodsModuleRegistryHack = global._apexMethodsModuleRegistryHack || {};
+        
           try {
             const {
               createApexTestWireAdapter
             } = require('@salesforce/wire-service-jest-util');
         
-            global.__lwcJestMock_myMethod = global.__lwcJestMock_myMethod || createApexTestWireAdapter(jest.fn().mockImplementation(() => Promise.resolve()));
-            myMethod = global.__lwcJestMock_myMethod;
+            global._apexMethodsModuleRegistryHack["@salesforce/apexContinuation/FooController.fooMethod"] = global._apexMethodsModuleRegistryHack["@salesforce/apexContinuation/FooController.fooMethod"] || createApexTestWireAdapter(jest.fn().mockImplementation(() => Promise.resolve()));
           } catch (wireServiceJestUtilNotDefined) {
-            global.__lwcJestMock_myMethod = global.__lwcJestMock_myMethod || function myMethod() {
+            global._apexMethodsModuleRegistryHack["@salesforce/apexContinuation/FooController.fooMethod"] = global._apexMethodsModuleRegistryHack["@salesforce/apexContinuation/FooController.fooMethod"] || function myMethod() {
               return Promise.resolve();
             };
-        
-            myMethod = global.__lwcJestMock_myMethod;
           }
+        
+          myMethod = global._apexMethodsModuleRegistryHack["@salesforce/apexContinuation/FooController.fooMethod"];
         }
     `
     );
@@ -45,24 +46,25 @@ describe('@salesforce/apexContinuation import', () => {
         `
         import { otherNamed } from './something-valid';
         let myMethod;
-
+        
         try {
           myMethod = require("@salesforce/apexContinuation/FooController.fooMethod").default;
         } catch (importSourceNotDefined) {
+          global._apexMethodsModuleRegistryHack = global._apexMethodsModuleRegistryHack || {};
+        
           try {
             const {
               createApexTestWireAdapter
             } = require('@salesforce/wire-service-jest-util');
         
-            global.__lwcJestMock_myMethod = global.__lwcJestMock_myMethod || createApexTestWireAdapter(jest.fn().mockImplementation(() => Promise.resolve()));
-            myMethod = global.__lwcJestMock_myMethod;
+            global._apexMethodsModuleRegistryHack["@salesforce/apexContinuation/FooController.fooMethod"] = global._apexMethodsModuleRegistryHack["@salesforce/apexContinuation/FooController.fooMethod"] || createApexTestWireAdapter(jest.fn().mockImplementation(() => Promise.resolve()));
           } catch (wireServiceJestUtilNotDefined) {
-            global.__lwcJestMock_myMethod = global.__lwcJestMock_myMethod || function myMethod() {
+            global._apexMethodsModuleRegistryHack["@salesforce/apexContinuation/FooController.fooMethod"] = global._apexMethodsModuleRegistryHack["@salesforce/apexContinuation/FooController.fooMethod"] || function myMethod() {
               return Promise.resolve();
             };
-        
-            myMethod = global.__lwcJestMock_myMethod;
           }
+        
+          myMethod = global._apexMethodsModuleRegistryHack["@salesforce/apexContinuation/FooController.fooMethod"];
         }
     `
     );

--- a/packages/@lwc/jest-transformer/src/transforms/__tests__/apex-scoped-import.test.js
+++ b/packages/@lwc/jest-transformer/src/transforms/__tests__/apex-scoped-import.test.js
@@ -18,20 +18,21 @@ describe('@salesforce/apex import', () => {
         try {
           myMethod = require("@salesforce/apex/FooController.fooMethod").default;
         } catch (importSourceNotDefined) {
+          global._apexMethodsModuleRegistryHack = global._apexMethodsModuleRegistryHack || {};
+        
           try {
             const {
               createApexTestWireAdapter
             } = require('@salesforce/wire-service-jest-util');
         
-            global.__lwcJestMock_myMethod = global.__lwcJestMock_myMethod || createApexTestWireAdapter(jest.fn().mockImplementation(() => Promise.resolve()));
-            myMethod = global.__lwcJestMock_myMethod;
+            global._apexMethodsModuleRegistryHack["@salesforce/apex/FooController.fooMethod"] = global._apexMethodsModuleRegistryHack["@salesforce/apex/FooController.fooMethod"] || createApexTestWireAdapter(jest.fn().mockImplementation(() => Promise.resolve()));
           } catch (wireServiceJestUtilNotDefined) {
-            global.__lwcJestMock_myMethod = global.__lwcJestMock_myMethod || function myMethod() {
+            global._apexMethodsModuleRegistryHack["@salesforce/apex/FooController.fooMethod"] = global._apexMethodsModuleRegistryHack["@salesforce/apex/FooController.fooMethod"] || function myMethod() {
               return Promise.resolve();
             };
-        
-            myMethod = global.__lwcJestMock_myMethod;
           }
+        
+          myMethod = global._apexMethodsModuleRegistryHack["@salesforce/apex/FooController.fooMethod"];
         }
     `
     );
@@ -49,20 +50,21 @@ describe('@salesforce/apex import', () => {
         try {
           myMethod = require("@salesforce/apex/FooController.fooMethod").default;
         } catch (importSourceNotDefined) {
+          global._apexMethodsModuleRegistryHack = global._apexMethodsModuleRegistryHack || {};
+        
           try {
             const {
               createApexTestWireAdapter
             } = require('@salesforce/wire-service-jest-util');
         
-            global.__lwcJestMock_myMethod = global.__lwcJestMock_myMethod || createApexTestWireAdapter(jest.fn().mockImplementation(() => Promise.resolve()));
-            myMethod = global.__lwcJestMock_myMethod;
+            global._apexMethodsModuleRegistryHack["@salesforce/apex/FooController.fooMethod"] = global._apexMethodsModuleRegistryHack["@salesforce/apex/FooController.fooMethod"] || createApexTestWireAdapter(jest.fn().mockImplementation(() => Promise.resolve()));
           } catch (wireServiceJestUtilNotDefined) {
-            global.__lwcJestMock_myMethod = global.__lwcJestMock_myMethod || function myMethod() {
+            global._apexMethodsModuleRegistryHack["@salesforce/apex/FooController.fooMethod"] = global._apexMethodsModuleRegistryHack["@salesforce/apex/FooController.fooMethod"] || function myMethod() {
               return Promise.resolve();
             };
-        
-            myMethod = global.__lwcJestMock_myMethod;
           }
+        
+          myMethod = global._apexMethodsModuleRegistryHack["@salesforce/apex/FooController.fooMethod"];
         }
     `
     );

--- a/packages/@lwc/jest-transformer/src/transforms/__tests__/apex-scoped-import.test.js
+++ b/packages/@lwc/jest-transformer/src/transforms/__tests__/apex-scoped-import.test.js
@@ -17,12 +17,21 @@ describe('@salesforce/apex import', () => {
 
         try {
           myMethod = require("@salesforce/apex/FooController.fooMethod").default;
-        } catch (e) {
-          global.__lwcJestMock_myMethod = global.__lwcJestMock_myMethod || function myMethod() {
-            return Promise.resolve();
-          };
-
-          myMethod = global.__lwcJestMock_myMethod;
+        } catch (importSourceNotDefined) {
+          try {
+            const {
+              createApexTestWireAdapter
+            } = require('@salesforce/wire-service-jest-util');
+        
+            global.__lwcJestMock_myMethod = global.__lwcJestMock_myMethod || createApexTestWireAdapter(jest.fn().mockImplementation(() => Promise.resolve()));
+            myMethod = global.__lwcJestMock_myMethod;
+          } catch (wireServiceJestUtilNotDefined) {
+            global.__lwcJestMock_myMethod = global.__lwcJestMock_myMethod || function myMethod() {
+              return Promise.resolve();
+            };
+        
+            myMethod = global.__lwcJestMock_myMethod;
+          }
         }
     `
     );
@@ -39,12 +48,21 @@ describe('@salesforce/apex import', () => {
 
         try {
           myMethod = require("@salesforce/apex/FooController.fooMethod").default;
-        } catch (e) {
-          global.__lwcJestMock_myMethod = global.__lwcJestMock_myMethod || function myMethod() {
-            return Promise.resolve();
-          };
-
-          myMethod = global.__lwcJestMock_myMethod;
+        } catch (importSourceNotDefined) {
+          try {
+            const {
+              createApexTestWireAdapter
+            } = require('@salesforce/wire-service-jest-util');
+        
+            global.__lwcJestMock_myMethod = global.__lwcJestMock_myMethod || createApexTestWireAdapter(jest.fn().mockImplementation(() => Promise.resolve()));
+            myMethod = global.__lwcJestMock_myMethod;
+          } catch (wireServiceJestUtilNotDefined) {
+            global.__lwcJestMock_myMethod = global.__lwcJestMock_myMethod || function myMethod() {
+              return Promise.resolve();
+            };
+        
+            myMethod = global.__lwcJestMock_myMethod;
+          }
         }
     `
     );

--- a/packages/@lwc/jest-transformer/src/transforms/apex-continuation-scoped-import.js
+++ b/packages/@lwc/jest-transformer/src/transforms/apex-continuation-scoped-import.js
@@ -21,7 +21,6 @@ module.exports = function ({ types: t }) {
                         resolvedPromiseTemplate({
                             RESOURCE_NAME: t.identifier(resourceNames[0]),
                             IMPORT_SOURCE: t.stringLiteral(importSource),
-                            MOCK_NAME: `__lwcJestMock_${resourceNames[0]}`,
                         })
                     );
                 }

--- a/packages/@lwc/jest-transformer/src/transforms/apex-scoped-import.js
+++ b/packages/@lwc/jest-transformer/src/transforms/apex-scoped-import.js
@@ -94,7 +94,6 @@ module.exports = function ({ types: t }) {
                         resolvedPromiseTemplate({
                             RESOURCE_NAME: t.identifier(resourceNames[0]),
                             IMPORT_SOURCE: t.stringLiteral(importSource),
-                            MOCK_NAME: `__lwcJestMock_${resourceNames[0]}`,
                         })
                     );
                 }

--- a/packages/@lwc/jest-transformer/src/transforms/utils.js
+++ b/packages/@lwc/jest-transformer/src/transforms/utils.js
@@ -78,14 +78,18 @@ const resolvedPromiseTemplate = babelTemplate(`
     try {
         RESOURCE_NAME = require(IMPORT_SOURCE).default;
     } catch (importSourceNotDefined) {
+        global._apexMethodsModuleRegistryHack = global._apexMethodsModuleRegistryHack || {};
+
         try {
             const { createApexTestWireAdapter } = require('@salesforce/wire-service-jest-util');
-            global.MOCK_NAME = global.MOCK_NAME || createApexTestWireAdapter(jest.fn().mockImplementation(() => Promise.resolve()));
-            RESOURCE_NAME = global.MOCK_NAME;
+            global._apexMethodsModuleRegistryHack[IMPORT_SOURCE] = global._apexMethodsModuleRegistryHack[IMPORT_SOURCE]
+                || createApexTestWireAdapter(jest.fn().mockImplementation(() => Promise.resolve()));
         } catch (wireServiceJestUtilNotDefined) {
-            global.MOCK_NAME = global.MOCK_NAME || function RESOURCE_NAME() { return Promise.resolve(); };
-            RESOURCE_NAME = global.MOCK_NAME;
+            global._apexMethodsModuleRegistryHack[IMPORT_SOURCE] = global._apexMethodsModuleRegistryHack[IMPORT_SOURCE]
+                || function RESOURCE_NAME() { return Promise.resolve(); };
         }
+        
+        RESOURCE_NAME = global._apexMethodsModuleRegistryHack[IMPORT_SOURCE];
     }
 `);
 

--- a/test/src/modules/transformer/apex/__tests__/apex-wire-jest-utils.test.js
+++ b/test/src/modules/transformer/apex/__tests__/apex-wire-jest-utils.test.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { ApexMethod, BarMethod } from '../apex';
+
+jest.mock(
+    '@salesforce/wire-service-jest-util',
+    () => {
+        return {
+            createApexTestWireAdapter: (fn) => {
+                fn.adapter = true;
+
+                return fn;
+            },
+        };
+    },
+    { virtual: true }
+);
+
+describe('@salesforce/apex/<class> when used with @salesforce/wire-service-jest-util', () => {
+    it('has different identities for different apex classes', () => {
+        expect(ApexMethod).not.toBe(BarMethod);
+    });
+
+    it('called createApexTestWireAdapter from @salesforce/wire-service-jest-util', () => {
+        expect(ApexMethod.adapter).toBe(true);
+    });
+
+    it('passes a jest.fn() to createApexTestWireAdapter', () => {
+        expect(ApexMethod.mock.calls).toHaveLength(0);
+        ApexMethod();
+        expect(ApexMethod.mock.calls).toHaveLength(1);
+    });
+
+    it('it has resolved promise as default implementation', () => {
+        return ApexMethod().then(() => expect(true).toBe(true));
+    });
+});
+

--- a/test/src/modules/transformer/apex/__tests__/apex.test.js
+++ b/test/src/modules/transformer/apex/__tests__/apex.test.js
@@ -4,11 +4,15 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { ApexMethod, refreshApex, getSObjectValue } from '../apex';
+import { ApexMethod, BarMethod, refreshApex, getSObjectValue } from '../apex';
 
 describe('@salesforce/apex/<class>', () => {
     it('exports a default method returning a promise', () => {
         expect(ApexMethod()).resolves.toEqual(undefined);
+    });
+
+    it('has different identities for different apex classes', () => {
+        expect(ApexMethod).not.toBe(BarMethod);
     });
 });
 

--- a/test/src/modules/transformer/apex/__tests__/apex.test.js
+++ b/test/src/modules/transformer/apex/__tests__/apex.test.js
@@ -5,6 +5,8 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { ApexMethod, BarMethod, refreshApex, getSObjectValue } from '../apex';
+import { ApexMethod as NotSameApexMethod } from '../otherApexConsumer';
+import FooMethod from '@salesforce/apex/FooClass.FooMethod';
 
 describe('@salesforce/apex/<class>', () => {
     it('exports a default method returning a promise', () => {
@@ -13,6 +15,18 @@ describe('@salesforce/apex/<class>', () => {
 
     it('has different identities for different apex classes', () => {
         expect(ApexMethod).not.toBe(BarMethod);
+    });
+
+    it('should be the same method when imported from the same apex module', () => {
+        // 2 modules consuming @salesforce/apex/FooClass.FooMethod should reference the same function.
+        expect(ApexMethod).toBe(FooMethod);
+    });
+
+    it('should be a different method when imported from a different apex modules with the same resource name', () => {
+        // 2 modules consuming different apex methods, via the same resource, eg:
+        // Module A: import apexMethod from '@salesforce/apex/FooClass.FooMethod';
+        // Module B: import apexMethod from '@salesforce/apex/BarClass.BarMethod';
+        expect(ApexMethod).not.toBe(NotSameApexMethod);
     });
 });
 

--- a/test/src/modules/transformer/apex/apex.js
+++ b/test/src/modules/transformer/apex/apex.js
@@ -5,6 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import ApexMethod from '@salesforce/apex/FooClass.FooMethod';
+import BarMethod from '@salesforce/apex/BarClass.BarMethod';
 import { refreshApex, getSObjectValue } from '@salesforce/apex';
 
-export { ApexMethod, refreshApex, getSObjectValue };
+export { ApexMethod, BarMethod, refreshApex, getSObjectValue };

--- a/test/src/modules/transformer/apex/otherApexConsumer.js
+++ b/test/src/modules/transformer/apex/otherApexConsumer.js
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import ApexMethod from '@salesforce/apex/BarClass.BarMethod';
+
+export { ApexMethod };


### PR DESCRIPTION
This PR modifies the jest-transformer to return a TestApexWireAdapter for apex (and apexContinuation) methods whenever `@salesforce/wire-service-jest-util` [library](https://github.com/salesforce/wire-service-jest-util) is available in the test environment. Also, when `@salesforce/wire-service-jest-util` is present, the apex method will be a `jest.fn()` with a mock implementation returning a resolved promise.

This PR also [fixes a bug](https://github.com/salesforce/lwc-test/pull/125/commits/1bbdd74d94defebe959632431a8d6221fd8deca6) when transforming apex (and apexContinuation) resources:

1. When modules A and B consume the same apex method, but via different import specifiers, they should reference the same apex method.
```js
// A
import apexMethod from '@salesforce/apex/Foo.fooMethod';
// B
import fooMethod from '@salesforce/apex/Foo.fooMethod';

// A(apexMethod) should be the same as B(fooMethod)
```
2. When modules A and B consume different apex methods, but via the same import specifier, they should reference different apex methods. Ex:
```js
// A
import apexMethod from '@salesforce/apex/Foo.fooMethod';
// B
import apexMethod from '@salesforce/apex/Bar.barMethod';

// A(apexMethod) should be different than B(apexMethod)
```