### PR TITLE
fix: warn if synthetic shadow is loaded twice

### DIFF
--- a/packages/@lwc/jest-preset/src/setup.js
+++ b/packages/@lwc/jest-preset/src/setup.js
@@ -2,6 +2,10 @@ const config = global['lwc-jest'] || {};
 const { nativeShadow } = config;
 
 if (!nativeShadow) {
+    if (ShadowRoot.prototype.constructor.toString().includes('function SyntheticShadowRoot')
+        || EventTarget.prototype.addEventListener.toString().includes('function patchedAddEventListener')) {
+        throw new Error('@lwc/synthetic-shadow is being loaded twice. Please examine your jest/jsdom configuration.')
+    }
     require('@lwc/synthetic-shadow/dist/synthetic-shadow.js');
 }
 


### PR DESCRIPTION
This adds an explicit error if we detect that `@lwc/synthetic-shadow` has been loaded twice by Jest. This would have saved me hours of debugging, so maybe it will save some time for the next person.

For the life of me, I can't figure out how to actually reproduce this in this repo. Even if I manually set `jest` and `jsdom` to exactly the versions in the other repo, I can't repro. However, I can at least confirm that, in the other repo, I can hit this line of code in their tests:

![Screen Shot 2021-08-20 at 9 13 51 AM](https://user-images.githubusercontent.com/283842/130263184-b63d9e9e-f189-4f06-9166-ee74146c66b9.png)

W-9786068