### PR TITLE
fix: fix manually setting template.stylesheets

### DIFF
--- a/test/src/modules/resolver/manualStylesheets/__tests__/manualStylesheets.test.js
+++ b/test/src/modules/resolver/manualStylesheets/__tests__/manualStylesheets.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { createElement } from 'lwc';
+import ManualStylesheets from '../manualStylesheets';
+
+it('works with attaching manual stylesheets', () => {
+    const element = createElement('resolver-basic', { is: ManualStylesheets });
+    document.body.appendChild(element);
+
+    expect(element.shadowRoot.querySelector('h1').textContent).toBe('Manual');
+});

--- a/test/src/modules/resolver/manualStylesheets/manualStylesheets.css
+++ b/test/src/modules/resolver/manualStylesheets/manualStylesheets.css
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-// CSS file returned by @lwc/jest-resolver. Since Jest/JSDOM doesn't really support CSS,
-// we always return a stub.
-module.exports = []; // empty array of stylesheets
+h1 {
+    color: red;
+}

--- a/test/src/modules/resolver/manualStylesheets/manualStylesheets.html
+++ b/test/src/modules/resolver/manualStylesheets/manualStylesheets.html
@@ -1,0 +1,9 @@
+<!--
+Copyright (c) 2018, salesforce.com, inc.
+All rights reserved.
+SPDX-License-Identifier: MIT
+For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+-->
+<template>
+    <h1>Manual</h1>
+</template>

--- a/test/src/modules/resolver/manualStylesheets/manualStylesheets.js
+++ b/test/src/modules/resolver/manualStylesheets/manualStylesheets.js
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { LightningElement } from 'lwc';
+
+import template from './manualStylesheets.html';
+import stylesheet from './manualStylesheets.css';
+
+export default class extends LightningElement {
+    render() {
+        // NOTE: This is an unsupported hack, but it's used in the wild, and it works outside of
+        // Jest, so for now we should support it.
+        template.stylesheets = [stylesheet];
+        return template;
+    }
+}


### PR DESCRIPTION
Manually setting the stylesheets on the template is not a supported scenario, but it happens to work:

```js
import template from './cmp.html'
import stylesheet from './cmp.css'

export default class extends LightningElement {
    render() {
        template.stylesheets = [stylesheet]
        return template
    }
}
```

(Note this works even if `stylesheet` is already an array, because the LWC runtime engine deeply recurses arrays of stylesheet functions.)

That is, it works in the browser using the standard `@lwc/rollup-plugin`, but it doesn't work in Jest. It throws an error:

```
TypeError: Cannot read property '$scoped$' of undefined
      at computeHasScopedStyles
```

This PR fixes that.

W-10686573