### PR TITLE
fix: render CSS correctly on both client and server

### DIFF
--- a/packages/@lwc/jest-preset/src/ssr/resolver.js
+++ b/packages/@lwc/jest-preset/src/ssr/resolver.js
@@ -4,48 +4,15 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-const fs = require("fs");
-const { extname, basename, resolve, dirname, join } = require("path");
 const lwcResolver = require('@lwc/jest-resolver');
 
 const ALLOWLISTED_LWC_PACKAGES = {
     lwc: '@lwc/engine-server',
 };
 
-function isValidCSSImport(importee, { basedir }) {
-    const ext = extname(importee);
-    const isCSS = ext === '.css';
-    let fileName = basename(importee, '.css');
-    const isScoped = extname(fileName) === '.scoped';
-    if (isScoped) {
-        fileName = basename(fileName, '.scoped');
-    }
-    const absPath = resolve(basedir, importee);
-    const dir = dirname(absPath);
-    const jsFile = join(dir, fileName + '.js');
-    const tsFile = join(dir, fileName + '.ts');
-
-    return (
-        // if it is a css file
-        isCSS &&
-        // the css file must exist
-        fs.existsSync(absPath) &&
-        // there must be a js/ts file with the same name in the same folder
-        (fs.existsSync(jsFile) || fs.existsSync(tsFile))
-    );
-}
-
 module.exports = function (path, options) {
-    const effectivePath = path.endsWith('?scoped=true') ? path.substring(0, path.length - 12) : path;
-
-    if (ALLOWLISTED_LWC_PACKAGES[effectivePath]) {
-        return options.defaultResolver(require.resolve(ALLOWLISTED_LWC_PACKAGES[effectivePath]), options);
-    }
-
-    // If it is a CSS and it exists, we should parse it since it must be rendered in ssr. The default resolver will
-    // just replace it with an empty string.
-    if (isValidCSSImport(effectivePath, options)) {
-        return options.defaultResolver(effectivePath, options);
+    if (ALLOWLISTED_LWC_PACKAGES[path]) {
+        return options.defaultResolver(require.resolve(ALLOWLISTED_LWC_PACKAGES[path]), options);
     }
 
     return lwcResolver(path, options);

--- a/test/src/modules/resolver/basic/__tests__/basic.test.js
+++ b/test/src/modules/resolver/basic/__tests__/basic.test.js
@@ -11,5 +11,16 @@ it('resolves basic component', () => {
     const element = createElement('resolver-basic', { is: Basic });
     document.body.appendChild(element);
 
-    expect(element.shadowRoot.querySelector('h1').textContent).toBe('Basic');
+    expect(element.shadowRoot.querySelector('h1').textContent).toEqual('Basic');
 });
+
+it('component has expected styles', () => {
+    const element = createElement('resolver-basic', { is: Basic });
+    document.body.appendChild(element);
+
+    const { nativeShadow } = global['lwc-jest']
+    const styleContainer = nativeShadow ? element.shadowRoot : document.head;
+    const css = styleContainer.querySelector('style').textContent;
+    const expectedCss = nativeShadow ? 'h1 {color: red;}' : 'h1[x-test_basic] {color: red;}'
+    expect(css).toEqual(expectedCss);
+})

--- a/test/src/modules/resolver/scopedCss/__tests__/scopedCss.test.js
+++ b/test/src/modules/resolver/scopedCss/__tests__/scopedCss.test.js
@@ -5,14 +5,13 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { createElement } from 'lwc';
-import NoCSS from '../noCss';
+import Basic from '../basic';
 
-it('resolves components without CSS', () => {
-    const element = createElement('resolver-no-css', { is: NoCSS });
+it('component has expected scoped styles', () => {
+    const element = createElement('resolver-basic', { is: Basic });
     document.body.appendChild(element);
 
-    expect(element.shadowRoot.querySelector('h1').textContent).toBe('No CSS');
-
     const styleContainer = global['lwc-jest'].nativeShadow ? element.shadowRoot : document.head;
-    expect(styleContainer.querySelectorAll('style').length).toEqual(0)
-});
+    const css = styleContainer.querySelector('style').textContent;
+    expect(css).toEqual('h1.x-test_basic {color: red;}');
+})

--- a/test/src/modules/resolver/scopedCss/basic.html
+++ b/test/src/modules/resolver/scopedCss/basic.html
@@ -1,0 +1,9 @@
+<!--
+Copyright (c) 2018, salesforce.com, inc.
+All rights reserved.
+SPDX-License-Identifier: MIT
+For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+-->
+<template>
+    <h1>Basic</h1>
+</template>

--- a/test/src/modules/resolver/scopedCss/basic.js
+++ b/test/src/modules/resolver/scopedCss/basic.js
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { LightningElement } from 'lwc';
+
+export default class Basic extends LightningElement {}

--- a/test/src/modules/resolver/scopedCss/basic.scoped.css
+++ b/test/src/modules/resolver/scopedCss/basic.scoped.css
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+h1 {
+    color: red;
+}


### PR DESCRIPTION
Currently, we only render CSS in server mode, not client mode. We should really render the CSS in both cases.

This moves the CSS rendering logic from `@lwc/jest-preset/src/ssr/resolver.js` to `@lwc/jest-resolver/src/index.js` and makes both the client and server resolver rely on the same logic.