### PR TITLE
chore: ignore expected console.error message

### DIFF
--- a/test/src/modules/resolver/manualStylesheets/__tests__/manualStylesheets.test.js
+++ b/test/src/modules/resolver/manualStylesheets/__tests__/manualStylesheets.test.js
@@ -7,6 +7,19 @@
 import { createElement } from 'lwc';
 import ManualStylesheets from '../manualStylesheets';
 
+// There is an expected deprecation error message we can ignore
+beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation((message) => {
+        if (!message.includes('Dynamically setting the "stylesheets" property on a template function is deprecated')) {
+            throw new Error('Unexpected console error message: ' + message)
+        }
+    });
+});
+
+afterEach(() => {
+    jest.restoreAllMocks();
+});
+
 it('works with attaching manual stylesheets', () => {
     const element = createElement('resolver-basic', { is: ManualStylesheets });
     document.body.appendChild(element);

--- a/test/src/modules/resolver/manualStylesheets/__tests__/manualStylesheets.test.js
+++ b/test/src/modules/resolver/manualStylesheets/__tests__/manualStylesheets.test.js
@@ -11,7 +11,7 @@ import ManualStylesheets from '../manualStylesheets';
 beforeEach(() => {
     jest.spyOn(console, 'error').mockImplementation((message) => {
         if (!message.includes('Dynamically setting the "stylesheets" property on a template function is deprecated')) {
-            throw new Error('Unexpected console error message: ' + message)
+            throw new Error('Unexpected console error message: ' + message);
         }
     });
 });


### PR DESCRIPTION
This disables an annoying error message in our tests:

<details><summary>Click to see</summary>

```
  ● Console                                                                                                                           
                                                                                                                                      
    console.error                                                                                                                     
      [LWC error]: Dynamically setting the "stylesheets" property on a template function is deprecated and may be removed in a future version of LWC.
                                                                                                                                      
      809 |     if (process.env.NODE_ENV === 'test') {                                                                                
      810 |         /* eslint-disable-next-line no-console */                                                                         
    > 811 |         console[method](msg);                                                                                             
          |         ^                                                                                                                 
      812 |         return;                                                                                                           
      813 |     }                                                                                                                     
      814 |     try {                                                                                                                 
                                                                                                                                      
      at console (../../lwc/packages/@lwc/engine-dom/dist/engine-dom.cjs.js:811:9)                                                    
      at log (../../lwc/packages/@lwc/engine-dom/dist/engine-dom.cjs.js:823:5)                                                        
      at Function.logError [as stylesheets] (../../lwc/packages/@lwc/engine-dom/dist/engine-dom.cjs.js:7218:25)                     
      at Object.<anonymous>._default.tmpl.template [as render] (src/modules/resolver/manualStylesheets/manualStylesheets.js:16:9)
      at apply (../../lwc/packages/@lwc/engine-dom/dist/engine-dom.cjs.js:5742:13)                                               
      at callHook (../../lwc/packages/@lwc/engine-dom/dist/engine-dom.cjs.js:5600:20)                                           
      at ReactiveObserver.job [as observe] (../../lwc/packages/@lwc/engine-dom/dist/engine-dom.cjs.js:697:13)                
      at observe (../../lwc/packages/@lwc/engine-dom/dist/engine-dom.cjs.js:5599:16)                                                  
      at job (../../lwc/packages/@lwc/engine-dom/dist/engine-dom.cjs.js:6352:5)                                                       
      at runWithBoundaryProtection (../../lwc/packages/@lwc/engine-dom/dist/engine-dom.cjs.js:5593:5)                                 
      at invokeComponentRenderMethod (../../lwc/packages/@lwc/engine-dom/dist/engine-dom.cjs.js:5663:20)                              
      at renderComponent (../../lwc/packages/@lwc/engine-dom/dist/engine-dom.cjs.js:6020:22)                                          
      at rehydrate (../../lwc/packages/@lwc/engine-dom/dist/engine-dom.cjs.js:5770:3)                                                 
      at fn (../../lwc/packages/@lwc/engine-dom/dist/engine-dom.cjs.js:7880:5)                                                        
      at HTMLBodyElement.callNodeSlot [as appendChild] (../../lwc/packages/@lwc/engine-dom/dist/engine-dom.cjs.js:7898:14)            
      at Object.appendChild (src/modules/resolver/manualStylesheets/__tests__/manualStylesheets.test.js:12:19)  
```

</details>

We know we're going to get this error message; we're deliberately testing this behavior.