### PR TITLE
feat(jest-transformer): enable scoped slots and lwc:spread feature by default for testing

### DIFF
--- a/packages/@lwc/jest-transformer/src/index.js
+++ b/packages/@lwc/jest-transformer/src/index.js
@@ -110,6 +110,8 @@ module.exports = {
                 strictSpecifier: false,
             },
             scopedStyles: getScopedStylesOption(src, filePath),
+            enableScopedSlots: true,
+            enableLwcSpread: true,
         });
 
         // if is not .js, we add the .compiled extension in the sourcemap


### PR DESCRIPTION
Note: These feature are still meant for internal usage and that is enforced at the compiler level. This PR only adds support for those feature when testing the components.