### PR TITLE
docs: fix typo in README

### DIFF
--- a/packages/@lwc/jest-serializer/README.md
+++ b/packages/@lwc/jest-serializer/README.md
@@ -1,3 +1,3 @@
-## jest-serializer
+## @lwc/jest-serializer
 
 Standarize snapshots for Shadow DOM.


### PR DESCRIPTION
We were missing the `@lwc` here.