### PR TITLE
fix: use ?scoped=true as signal for scoped CSS

### DIFF
--- a/packages/@lwc/jest-resolver/src/index.js
+++ b/packages/@lwc/jest-resolver/src/index.js
@@ -6,6 +6,8 @@
  */
 const fs = require('fs');
 const { resolve, extname, join, dirname, basename } = require('path');
+const { URLSearchParams } = require('url')
+const { addKnownScopedCssFile } = require('@lwc/jest-shared');
 
 const EMPTY_CSS_MOCK = resolve(__dirname, '..', 'resources', 'emptyStyleMock.js');
 const EMPTY_HTML_MOCK = resolve(__dirname, '..', 'resources', 'emptyHtmlMock.js');
@@ -55,10 +57,17 @@ function isValidScriptImport(importee, { basedir }) {
     return fs.existsSync(absPath)
 }
 
+function parseForQueryParams(path) {
+    const [ filename, search ] = path.split('?')
+    const params = new URLSearchParams(search);
+    return { filename, params };
+}
+
 function getLwcPath(path, options) {
-    if (path.endsWith('?scoped=true')) {
-        // remove query param for scoped styles
-        path = path.substring(0, path.length - 12);
+    const { filename, params } = parseForQueryParams(path);
+    path = filename; // remove query param for scoped styles (`?scoped=true`)
+    if (params.get('scoped') === 'true') {
+        addKnownScopedCssFile(resolve(options.basedir, path));
     }
     // If is a special LWC package, resolve it from commonjs
     if (ALLOWLISTED_LWC_PACKAGES[path]) {

--- a/packages/@lwc/jest-resolver/src/index.js
+++ b/packages/@lwc/jest-resolver/src/index.js
@@ -6,7 +6,7 @@
  */
 const fs = require('fs');
 const { resolve, extname, join, dirname, basename } = require('path');
-const { URLSearchParams } = require('url')
+const { URLSearchParams } = require('url');
 const { addKnownScopedCssFile } = require('@lwc/jest-shared');
 
 const EMPTY_CSS_MOCK = resolve(__dirname, '..', 'resources', 'emptyStyleMock.js');

--- a/packages/@lwc/jest-resolver/src/index.js
+++ b/packages/@lwc/jest-resolver/src/index.js
@@ -59,8 +59,8 @@ function isValidScriptImport(importee, { basedir }) {
 
 function parseForQueryParams(path) {
     // There is a chance that the filename contains a ? character, but Jest itself throws an error in this case.
-    // Even if there is a ? in a parent/grandparent folder, this function only parses the immediate path,
-    // so it doesn't matter.
+    // Even if there is a ? in a parent/grandparent folder, this function only parses the immediate path (e.g.
+    // `./filename.css`), so it doesn't matter.
     const [ filename, search ] = path.split('?')
     const params = new URLSearchParams(search);
     return { filename, params };

--- a/packages/@lwc/jest-resolver/src/index.js
+++ b/packages/@lwc/jest-resolver/src/index.js
@@ -58,6 +58,9 @@ function isValidScriptImport(importee, { basedir }) {
 }
 
 function parseForQueryParams(path) {
+    // There is a chance that the filename contains a ? character, but Jest itself throws an error in this case.
+    // Even if there is a ? in a parent/grandparent folder, this function only parses the immediate path,
+    // so it doesn't matter.
     const [ filename, search ] = path.split('?')
     const params = new URLSearchParams(search);
     return { filename, params };

--- a/packages/@lwc/jest-resolver/src/index.js
+++ b/packages/@lwc/jest-resolver/src/index.js
@@ -61,7 +61,7 @@ function parseForQueryParams(path) {
     // There is a chance that the filename contains a ? character, but Jest itself throws an error in this case.
     // Even if there is a ? in a parent/grandparent folder, this function only parses the immediate path (e.g.
     // `./filename.css`), so it doesn't matter.
-    const [ filename, search ] = path.split('?')
+    const [ filename, search ] = path.split('?');
     const params = new URLSearchParams(search);
     return { filename, params };
 }

--- a/packages/@lwc/jest-shared/README.md
+++ b/packages/@lwc/jest-shared/README.md
@@ -1,0 +1,5 @@
+## @lwc/jest-shared
+
+Shared internal code for LWC Jest packages.
+
+Note that you should probably not be using this package directly! Likely, you should use `@lwc/jest-preset` instead.

--- a/packages/@lwc/jest-shared/package.json
+++ b/packages/@lwc/jest-shared/package.json
@@ -1,12 +1,12 @@
 {
-    "name": "@lwc/jest-resolver",
+    "name": "@lwc/jest-shared",
     "version": "11.7.0",
-    "description": "Jest resolver to resolve LWC specific packages",
+    "description": "Shared internal code for LWC Jest packages",
     "homepage": "https://lwc.dev/",
     "repository": {
         "type": "git",
         "url": "https://github.com/salesforce/lwc-test.git",
-        "directory": "packages/@lwc/jest-resolver"
+        "directory": "packages/@lwc/jest-shared"
     },
     "bugs": {
         "url": "https://github.com/salesforce/lwc-test/issues"
@@ -17,16 +17,6 @@
         "jest",
         "lwc"
     ],
-    "files": [
-        "/resources/",
-        "/src/index.js"
-    ],
-    "dependencies": {
-        "@lwc/jest-shared": "11.7.0"
-    },
-    "peerDependencies": {
-        "jest": "^26 || ^27 || ^28 || ^29"
-    },
     "engines": {
         "node": ">=10"
     }

--- a/packages/@lwc/jest-shared/src/index.js
+++ b/packages/@lwc/jest-shared/src/index.js
@@ -1,0 +1,23 @@
+const knownScopedCssFiles = new Set()
+
+/**
+ * Indicate that this file is a scoped CSS file.
+ * @param filename - full absolute file path
+ */
+function addKnownScopedCssFile(filename) {
+    knownScopedCssFiles.add(filename)
+}
+
+/**
+ * Check if this file is a scoped CSS file.
+ * @param filename - full absolute file path
+ * @returns {boolean} - true if scoped
+ */
+function isKnownScopedCssFile(filename) {
+    return knownScopedCssFiles.has(filename)
+}
+
+module.exports = {
+    addKnownScopedCssFile,
+    isKnownScopedCssFile
+}

--- a/packages/@lwc/jest-shared/src/index.js
+++ b/packages/@lwc/jest-shared/src/index.js
@@ -1,11 +1,11 @@
-const knownScopedCssFiles = new Set()
+const knownScopedCssFiles = new Set();
 
 /**
  * Indicate that this file is a scoped CSS file.
  * @param filename - full absolute file path
  */
 function addKnownScopedCssFile(filename) {
-    knownScopedCssFiles.add(filename)
+    knownScopedCssFiles.add(filename);
 }
 
 /**
@@ -14,10 +14,10 @@ function addKnownScopedCssFile(filename) {
  * @returns {boolean} - true if scoped
  */
 function isKnownScopedCssFile(filename) {
-    return knownScopedCssFiles.has(filename)
+    return knownScopedCssFiles.has(filename);
 }
 
 module.exports = {
     addKnownScopedCssFile,
     isKnownScopedCssFile
-}
+};

--- a/packages/@lwc/jest-transformer/package.json
+++ b/packages/@lwc/jest-transformer/package.json
@@ -28,6 +28,7 @@
         "@babel/plugin-syntax-decorators": "^7.19.0",
         "@babel/plugin-transform-modules-commonjs": "^7.19.6",
         "@babel/preset-typescript": "^7.18.6",
+        "@lwc/jest-shared": "11.7.0",
         "babel-preset-jest": "^29.2.0"
     },
     "peerDependencies": {

--- a/packages/@lwc/jest-transformer/src/index.js
+++ b/packages/@lwc/jest-transformer/src/index.js
@@ -7,6 +7,8 @@
 const path = require('path');
 const crypto = require('crypto');
 
+const { isKnownScopedCssFile } = require('@lwc/jest-shared');
+
 const babelCore = require('@babel/core');
 const lwcCompiler = require('@lwc/compiler');
 const jestPreset = require('babel-preset-jest');
@@ -84,15 +86,6 @@ function transformTypeScript(src, filePath) {
     return code;
 }
 
-function getScopedStylesOption(src, filePath) {
-    const ext = path.extname(filePath);
-    const isCSS = ext === '.css';
-    const fileName = path.basename(filePath, '.css');
-    const isScoped = path.extname(fileName) === '.scoped';
-
-    return src && src.length > 0 && isCSS && isScoped;
-}
-
 module.exports = {
     process(src, filePath) {
         if (isTypeScript(filePath)) {
@@ -109,7 +102,7 @@ module.exports = {
             experimentalDynamicComponent: {
                 strictSpecifier: false,
             },
-            scopedStyles: getScopedStylesOption(src, filePath),
+            scopedStyles: isKnownScopedCssFile(filePath),
             enableScopedSlots: true,
             enableLwcSpread: true,
         });


### PR DESCRIPTION
Currently `lwc-test` is the only case where we use `.scoped.css` in the filename as a signal for whether a CSS file is scoped or not. Technically we should be using the presence of `?scoped=true`.

In Jest, I could not figure out a way to plumb the query param through from the resolver to the transformer. Research on how to do this turned up nothing.

The simplest solution I could find is to create a new package, `@lwc/jest-shared`, which serves as a communication mechanism between `@lwc/jest-resolver` and `@lwc/jest-transformer`. One notes the presence of `?scoped=true`, whereas the other looks up a filename later to see if it should be treated as scoped.