### PR TITLE
feat(jest-transformer): enable new dynamic components

### DIFF
--- a/packages/@lwc/jest-transformer/src/index.js
+++ b/packages/@lwc/jest-transformer/src/index.js
@@ -104,6 +104,7 @@ module.exports = {
             },
             scopedStyles: isKnownScopedCssFile(filePath),
             enableLwcSpread: true,
+            enableDynamicComponents: true
         });
 
         // if is not .js, we add the .compiled extension in the sourcemap

--- a/test/src/modules/smoke/dynamicCmp/__tests__/__snapshots__/dynamicCmp.test.js.snap
+++ b/test/src/modules/smoke/dynamicCmp/__tests__/__snapshots__/dynamicCmp.test.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render dynamically imported component 1`] = `
+<smoke-dynamic-import>
+  #shadow-root(open)
+    <x-test>
+      #shadow-root(open)
+        <span>
+          Child
+        </span>
+    </x-test>
+</smoke-dynamic-import>
+`;

--- a/test/src/modules/smoke/dynamicCmp/__tests__/dynamicCmp.test.js
+++ b/test/src/modules/smoke/dynamicCmp/__tests__/dynamicCmp.test.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { createElement } from 'lwc';
+import DynamicCmp from '../dynamicCmp';
+
+it('should render dynamically imported component', (done) => {
+    const element = createElement('smoke-dynamic-import', { is: DynamicCmp });
+    document.body.appendChild(element);
+
+    setTimeout(() => {
+        expect(element).toMatchSnapshot();
+        done();
+    });
+});

--- a/test/src/modules/smoke/dynamicCmp/dynamicCmp.html
+++ b/test/src/modules/smoke/dynamicCmp/dynamicCmp.html
@@ -1,0 +1,3 @@
+<template>
+    <lwc:component lwc:is={ctor}></lwc:component>
+</template>

--- a/test/src/modules/smoke/dynamicCmp/dynamicCmp.js
+++ b/test/src/modules/smoke/dynamicCmp/dynamicCmp.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    ctor = null;
+
+    connectedCallback() {
+        this.loadCtor();
+    }
+
+    async loadCtor() {
+        const moduleName = 'smoke/child';
+        const module = await import(moduleName);
+
+        this.ctor = module.default;
+    }
+}


### PR DESCRIPTION
This PR enables [dynamic components](https://github.com/salesforce/lwc-rfcs/blob/master/text/0133-dynamic-component-creation.md) for testing.

This PR only enables dynamic components, a follow-up PR will be needed to retrieve the namespace and name to properly create a dynamic component with the correct tag name which is a breaking change.

In 244, the users of dynamic components are internal developers and a pilot group of ISVs. 