### PR TITLE
fix: future-proof against changes to synthetic shadow

### DIFF
--- a/packages/@lwc/jest-preset/src/setup.js
+++ b/packages/@lwc/jest-preset/src/setup.js
@@ -12,7 +12,19 @@ if (!nativeShadow) {
             '@lwc/synthetic-shadow is being loaded twice. Please examine your jest/jsdom configuration.'
         );
     }
-    require('@lwc/synthetic-shadow/dist/synthetic-shadow.js');
+    try {
+        // In old versions of @lwc/synthetic shadow (<3.0.0), `require('@lwc/synthetic-shadow')`
+        // is a no-op, and you have to directly require the actual main file.
+        require('@lwc/synthetic-shadow/dist/synthetic-shadow.js');
+    } catch (err) {
+        // In newer versions of @lwc/synthetic-shadow (>=3.0.0), the above file does not exist,
+        // and you can `require()` normally.
+        if (err && err.code === 'MODULE_NOT_FOUND') {
+            require('@lwc/synthetic-shadow');
+        } else {
+            throw err;
+        }
+    }
 }
 
 // Provides temporary backward compatibility for wire-protocol reform: lwc > 1.5.0

--- a/packages/@lwc/jest-preset/src/setup.js
+++ b/packages/@lwc/jest-preset/src/setup.js
@@ -13,12 +13,14 @@ if (!nativeShadow) {
         );
     }
     try {
-        // In old versions of @lwc/synthetic shadow (<3.0.0), `require('@lwc/synthetic-shadow')`
-        // is a no-op, and you have to directly require the actual main file.
+        // Prior to @lwc/synthetic-shadow v2.45.3, calling `require('@lwc/synthetic-shadow')`
+        // is a no-op, and you have to directly require the file below.
+        // At some point (probably LWC v3.0.0), the below line should throw because the file does
+        // not exist anymore. See: https://github.com/salesforce/lwc/pull/3456
         require('@lwc/synthetic-shadow/dist/synthetic-shadow.js');
     } catch (err) {
-        // In newer versions of @lwc/synthetic-shadow (>=3.0.0), the above file does not exist,
-        // and you can `require()` normally.
+        // In newer versions of @lwc/synthetic-shadow, you can just do
+        // `require('@lwc/synthetic-shadow')` normally.
         if (err && err.code === 'MODULE_NOT_FOUND') {
             require('@lwc/synthetic-shadow');
         } else {


### PR DESCRIPTION
In https://github.com/salesforce/lwc/pull/3456 I plan to move the location of the `dist/` file for `@lwc/synthetic-shadow`. We are directly depending on the current location:

https://github.com/salesforce/lwc-test/blob/69fdc0c8ed1fe3522fab01049b305cf5b5b2d0f1/packages/%40lwc/jest-preset/src/setup.js#L15

This PR future-proofs us, so that we work with either the old or new location.