### PR TITLE
fix(serializer): replace LWC scope tokens

### DIFF
--- a/packages/@lwc/jest-serializer/package.json
+++ b/packages/@lwc/jest-serializer/package.json
@@ -18,6 +18,7 @@
         "lwc"
     ],
     "dependencies": {
+        "@lwc/jest-shared": "11.8.0",
         "pretty-format": "^29.5.0"
     },
     "peerDependencies": {

--- a/packages/@lwc/jest-serializer/src/clean-element-attrs.js
+++ b/packages/@lwc/jest-serializer/src/clean-element-attrs.js
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2018, salesforce.com, inc.
+ * Copyright (c) 2023, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+const { isKnownScopeToken } = require('@lwc/jest-shared');
 const GUID_ATTR_VALUE = '[shadow:guid]';
 const FRAG_ID_ATTR_VALUE = `#${GUID_ATTR_VALUE}`;
 
@@ -51,6 +52,13 @@ function cleanElementAttributes(elm) {
     ATTRS_TO_REMOVE.forEach((name) => {
         elm.removeAttribute(name);
     });
+
+    for (const { name, value } of [...elm.attributes]) {
+        if (isKnownScopeToken(name)) {
+            elm.removeAttribute(name);
+            elm.setAttribute('__lwc_scope_token__', value);
+        }
+    }
 }
 
 module.exports = cleanElementAttributes;

--- a/packages/@lwc/jest-serializer/src/clean-element-classes.js
+++ b/packages/@lwc/jest-serializer/src/clean-element-classes.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+const { isKnownScopeToken } = require('@lwc/jest-shared');
+
+function cleanElementClasses(elm) {
+    for (const name of [...elm.classList]) {
+        if (isKnownScopeToken(name)) {
+            elm.classList.replace(name, '__lwc_scope_token__');
+        }
+    }
+}
+
+module.exports = cleanElementClasses;

--- a/packages/@lwc/jest-serializer/src/clean-style-element.js
+++ b/packages/@lwc/jest-serializer/src/clean-style-element.js
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+const { getKnownScopeTokens } = require('@lwc/jest-shared');
+
+function cleanStyleElement(elm) {
+    // attributes in the HTML namespace are case-insensitive, so we treat everything as lowercase
+    const regex = new RegExp(getKnownScopeTokens().join('|'), 'gi');
+    elm.textContent = elm.textContent.replace(regex, '__lwc_scope_token__');
+}
+
+module.exports = cleanStyleElement;

--- a/packages/@lwc/jest-serializer/src/index.js
+++ b/packages/@lwc/jest-serializer/src/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, salesforce.com, inc.
+ * Copyright (c) 2023, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -8,6 +8,8 @@ const PrettyFormat = require('pretty-format');
 const DOMElement = PrettyFormat.plugins.DOMElement;
 
 const cleanElementAttributes = require('./clean-element-attrs');
+const cleanElementClasses = require('./clean-element-classes');
+const cleanStyleElement = require('./clean-style-element');
 
 function test(obj) {
     if (typeof obj !== 'object' || obj === null) {
@@ -52,6 +54,10 @@ function serialize(node, config, indentation, depth, refs, printer) {
     const isElement = node.nodeType === 1;
     if (isElement) {
         cleanElementAttributes(node);
+        cleanElementClasses(node);
+        if (node.tagName === 'STYLE') {
+            cleanStyleElement(node);
+        }
     }
 
     const lightChildren = Array.prototype.slice.call(node.childNodes);

--- a/packages/@lwc/jest-shared/src/index.js
+++ b/packages/@lwc/jest-shared/src/index.js
@@ -17,7 +17,40 @@ function isKnownScopedCssFile(filename) {
     return knownScopedCssFiles.has(filename);
 }
 
+const knownScopeTokens = new Set();
+
+/**
+ * Indicate that this string is a scope token (used by LWC for style scoping).
+ * @param str - scope token string
+ */
+function addKnownScopeToken(str) {
+    // attributes in the HTML namespace are case-insensitive, so we treat everything as lowercase
+    knownScopeTokens.add(str.toLowerCase());
+}
+
+/**
+ * Check if this string is a known scope token
+ * @param str - string to check
+ * @returns {boolean} - true if it's a known scope token
+ */
+function isKnownScopeToken(str) {
+    // attributes in the HTML namespace are case-insensitive, so we treat everything as lowercase
+    return knownScopeTokens.has(str.toLowerCase());
+}
+
+/**
+ * Get all known scope tokens
+ @returns {tokens} - list of known scope tokens
+ */
+function getKnownScopeTokens() {
+    // attributes in the HTML namespace are case-insensitive, so we treat everything as lowercase
+    return [...knownScopeTokens];
+}
+
 module.exports = {
     addKnownScopedCssFile,
-    isKnownScopedCssFile
+    isKnownScopedCssFile,
+    addKnownScopeToken,
+    isKnownScopeToken,
+    getKnownScopeTokens,
 };

--- a/packages/@lwc/jest-transformer/package.json
+++ b/packages/@lwc/jest-transformer/package.json
@@ -29,7 +29,8 @@
         "@babel/plugin-transform-modules-commonjs": "^7.21.2",
         "@babel/preset-typescript": "^7.21.0",
         "@lwc/jest-shared": "11.8.0",
-        "babel-preset-jest": "^29.5.0"
+        "babel-preset-jest": "^29.5.0",
+        "magic-string": "^0.30.0"
     },
     "peerDependencies": {
         "@lwc/compiler": "*",

--- a/test/src/modules/serializer/styledMultiple/__tests__/styledMultiple.spec.js
+++ b/test/src/modules/serializer/styledMultiple/__tests__/styledMultiple.spec.js
@@ -5,10 +5,10 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { createElement } from 'lwc';
-import Styled from '../styled';
+import StyledMultiple from '../styledMultiple';
 
-it('serializes component with HTML - styled in shadow DOM', () => {
-    const elm = createElement('serializer-component', { is: Styled });
+it('serializes component with HTML - styled in shadow DOM - multiple attrs/classes/styles', () => {
+    const elm = createElement('serializer-component', { is: StyledMultiple });
     document.body.appendChild(elm);
 
     if (global['lwc-jest'].nativeShadow) {
@@ -20,17 +20,19 @@ it('serializes component with HTML - styled in shadow DOM', () => {
                 <style
                   type="text/css"
                 >
-                  h1 {color: red;}
+                  :host {opacity: 0.5;}h1 {color: red;}.foo {background: azure;}
                 </style>
                 <style
                   type="text/css"
                 >
-                  h1.__lwc_scope_token__ {background: blue;}
+                  :host {color: goldenrod;}h1.__lwc_scope_token__ {background: blue;}.foo.__lwc_scope_token__ {opacity: 0.7;}
                 </style>
                 <h1
-                  class="__lwc_scope_token__"
+                  class="foo bar __lwc_scope_token__"
+                  data-bar="bar"
+                  data-foo="foo"
                 >
-                  I am an LWC component
+                  I am an LWC component with multiple classes, attributes, and styles
                 </h1>
             </serializer-component>
         `);
@@ -43,9 +45,11 @@ it('serializes component with HTML - styled in shadow DOM', () => {
               #shadow-root(open)
                 <h1
                   __lwc_scope_token__=""
-                  class="__lwc_scope_token__"
+                  class="foo bar __lwc_scope_token__"
+                  data-bar="bar"
+                  data-foo="foo"
                 >
-                  I am an LWC component
+                  I am an LWC component with multiple classes, attributes, and styles
                 </h1>
             </serializer-component>
         `);

--- a/test/src/modules/serializer/styledMultiple/styledMultiple.css
+++ b/test/src/modules/serializer/styledMultiple/styledMultiple.css
@@ -1,0 +1,11 @@
+:host {
+    opacity: 0.5;
+}
+
+h1 {
+    color: red;
+}
+
+.foo {
+    background: azure;
+}

--- a/test/src/modules/serializer/styledMultiple/styledMultiple.html
+++ b/test/src/modules/serializer/styledMultiple/styledMultiple.html
@@ -1,0 +1,7 @@
+<template>
+    <h1
+        class="foo bar"
+        data-foo="foo"
+        data-bar="bar"
+    >I am an LWC component with multiple classes, attributes, and styles</h1>
+</template>

--- a/test/src/modules/serializer/styledMultiple/styledMultiple.js
+++ b/test/src/modules/serializer/styledMultiple/styledMultiple.js
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+}

--- a/test/src/modules/serializer/styledMultiple/styledMultiple.scoped.css
+++ b/test/src/modules/serializer/styledMultiple/styledMultiple.scoped.css
@@ -1,0 +1,11 @@
+:host {
+    color: goldenrod;
+}
+
+h1 {
+    background: blue;
+}
+
+.foo {
+    opacity: 0.7;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -977,6 +977,11 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
   integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
 
+"@jridgewell/sourcemap-codec@^1.4.13":
+  version "1.4.15"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
+  integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
+
 "@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.15", "@jridgewell/trace-mapping@^0.3.17", "@jridgewell/trace-mapping@^0.3.9":
   version "0.3.17"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz#793041277af9073b0951a7fe0f0d8c4c98c36985"
@@ -5042,6 +5047,13 @@ lru-cache@^7.4.4, lru-cache@^7.5.1, lru-cache@^7.7.1:
   version "7.16.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.16.1.tgz#7acea16fecd9ed11430e78443c2bb81a06d3dea9"
   integrity sha512-9kkuMZHnLH/8qXARvYSjNvq8S1GYFFzynQTAfKeaJ0sIrR3PUPuu37Z+EiIANiZBvpfTf2B5y8ecDLSMWlLv+w==
+
+magic-string@^0.30.0:
+  version "0.30.0"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.0.tgz#fd58a4748c5c4547338a424e90fa5dd17f4de529"
+  integrity sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.4.13"
 
 make-dir@3.1.0, make-dir@^3.0.0:
   version "3.1.0"


### PR DESCRIPTION
This is a PoC of replacing the scope tokens in serialized templates. In serialized HTML, all scope tokens are replaced with `__lwc_scope_token__`.

This should eventually allow us to implement lowercasing of scope tokens (https://github.com/salesforce/lwc/issues/3313) because it would no longer be a breaking change, since the snapshot will not change if the scope token changes.