### PR TITLE
fix(ssr): replace scope token in SSR serializer

### DIFF
--- a/packages/@lwc/jest-preset/src/ssr/html-serializer.js
+++ b/packages/@lwc/jest-preset/src/ssr/html-serializer.js
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+const { getKnownScopeTokensRegex } = require('@lwc/jest-shared');
+
 const HTML_NAMESPACE = 'http://www.w3.org/1999/xhtml';
 
 // Void elements are elements that self-close even without an explicit solidus (slash),
@@ -93,7 +95,7 @@ function formatHTML(src) {
         }
     }
 
-    return res.trim();
+    return res.trim().replace(getKnownScopeTokensRegex(), '__lwc_scope_token__');
 }
 
 module.exports = {

--- a/packages/@lwc/jest-serializer/src/clean-style-element.js
+++ b/packages/@lwc/jest-serializer/src/clean-style-element.js
@@ -5,12 +5,10 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-const { getKnownScopeTokens } = require('@lwc/jest-shared');
+const { getKnownScopeTokensRegex } = require('@lwc/jest-shared');
 
 function cleanStyleElement(elm) {
-    // attributes in the HTML namespace are case-insensitive, so the regex must be case-insensitive
-    const regex = new RegExp(getKnownScopeTokens().join('|'), 'gi');
-    elm.textContent = elm.textContent.replace(regex, '__lwc_scope_token__');
+    elm.textContent = elm.textContent.replace(getKnownScopeTokensRegex(), '__lwc_scope_token__');
 }
 
 module.exports = cleanStyleElement;

--- a/packages/@lwc/jest-shared/src/index.js
+++ b/packages/@lwc/jest-shared/src/index.js
@@ -39,11 +39,12 @@ function isKnownScopeToken(str) {
 }
 
 /**
- * Get all known scope tokens
- @returns {string[]} - list of known scope tokens
+ * Get a regex matching all known scope tokens
+ @returns {RegExp} - regex representing the list of known scope tokens
  */
-function getKnownScopeTokens() {
-    return [...knownScopeTokens];
+function getKnownScopeTokensRegex() {
+    // attributes in the HTML namespace are case-insensitive, so the regex must be case-insensitive
+    return new RegExp([...knownScopeTokens].join('|'), 'gi');
 }
 
 module.exports = {
@@ -51,5 +52,5 @@ module.exports = {
     isKnownScopedCssFile,
     addKnownScopeToken,
     isKnownScopeToken,
-    getKnownScopeTokens,
+    getKnownScopeTokensRegex,
 };

--- a/test/src/modules/ssr/scopedStyle/__tests__/scopedStyle.ssr-test.js
+++ b/test/src/modules/ssr/scopedStyle/__tests__/scopedStyle.ssr-test.js
@@ -11,12 +11,12 @@ it('renders a basic component with scoped styles', () => {
     const renderedComponent = renderComponent('x-scoped-style', ScopedStyle);
 
     expect(renderedComponent).toMatchInlineSnapshot(`
-        <x-scoped-style class="x-test_scopedStyle-host">
+        <x-scoped-style class="__lwc_scope_token__-host">
           <template shadowroot="open">
-            <style class="x-test_scopedStyle" type="text/css">
-              h1.x-test_scopedStyle {color: red;}
+            <style class="__lwc_scope_token__" type="text/css">
+              h1.__lwc_scope_token__ {color: red;}
             </style>
-            <h1 class="x-test_scopedStyle">
+            <h1 class="__lwc_scope_token__">
               Scoped style test
             </h1>
           </template>


### PR DESCRIPTION
This was an oversight in #185. I missed doing this for SSR snapshots.

Arguably this is a breaking change, but I'm going to consider it a bugfix because it should have been done in v12.0.0.