### PR TITLE
fix: remove synthetic shadow fallback import for real

### DIFF
--- a/packages/@lwc/jest-preset/src/setup.js
+++ b/packages/@lwc/jest-preset/src/setup.js
@@ -12,7 +12,7 @@ if (!nativeShadow) {
             '@lwc/synthetic-shadow is being loaded twice. Please examine your jest/jsdom configuration.'
         );
     }
-    require('@lwc/synthetic-shadow/dist/synthetic-shadow.js');
+    require('@lwc/synthetic-shadow');
 }
 
 // Provides temporary backward compatibility for wire-protocol reform: lwc > 1.5.0


### PR DESCRIPTION
I missed this in #186. I removed the wrong import. 🤦 