### PR TITLE
fix(serializer): remove "-host" from serialized scope token

### DIFF
--- a/packages/@lwc/jest-shared/src/index.js
+++ b/packages/@lwc/jest-shared/src/index.js
@@ -46,7 +46,7 @@ function getKnownScopeTokensRegex() {
     // sort from longest to shortest so that `{foo-host}` is fully replaced, not just `{foo}-host`
     const regexString = [...knownScopeTokens]
         .sort((a, b) => b.length - a.length)
-        .join('|')
+        .join('|');
     // attributes in the HTML namespace are case-insensitive, so the regex must be case-insensitive
     return new RegExp(regexString, 'gi');
 }

--- a/packages/@lwc/jest-shared/src/index.js
+++ b/packages/@lwc/jest-shared/src/index.js
@@ -43,8 +43,12 @@ function isKnownScopeToken(str) {
  @returns {RegExp} - regex representing the list of known scope tokens
  */
 function getKnownScopeTokensRegex() {
+    // sort from longest to shortest so that `{foo-host}` is fully replaced, not just `{foo}-host`
+    const regexString = [...knownScopeTokens]
+        .sort((a, b) => b.length - a.length)
+        .join('|')
     // attributes in the HTML namespace are case-insensitive, so the regex must be case-insensitive
-    return new RegExp([...knownScopeTokens].join('|'), 'gi');
+    return new RegExp(regexString, 'gi');
 }
 
 module.exports = {

--- a/test/src/modules/ssr/scopedStyle/__tests__/scopedStyle.ssr-test.js
+++ b/test/src/modules/ssr/scopedStyle/__tests__/scopedStyle.ssr-test.js
@@ -11,7 +11,7 @@ it('renders a basic component with scoped styles', () => {
     const renderedComponent = renderComponent('x-scoped-style', ScopedStyle);
 
     expect(renderedComponent).toMatchInlineSnapshot(`
-        <x-scoped-style class="__lwc_scope_token__-host">
+        <x-scoped-style class="__lwc_scope_token__">
           <template shadowroot="open">
             <style class="__lwc_scope_token__" type="text/css">
               h1.__lwc_scope_token__ {color: red;}

--- a/test/src/modules/ssr/scopedStyleHostLight/__tests__/scopedStyleHostLight.ssr-test.js
+++ b/test/src/modules/ssr/scopedStyleHostLight/__tests__/scopedStyleHostLight.ssr-test.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { renderComponent } from 'lwc';
+import ScopedStyleHostLight from 'ssr/scopedStyleHostLight';
+
+it('renders a basic component with scoped styles, light DOM with :host', () => {
+    const renderedComponent = renderComponent('x-scoped-style', ScopedStyleHostLight);
+
+    expect(renderedComponent).toMatchInlineSnapshot(`
+        <x-scoped-style class="__lwc_scope_token__">
+          <style class="__lwc_scope_token__" type="text/css">
+            h1.__lwc_scope_token__ {color: red;}.__lwc_scope_token__ {color: blue;}
+          </style>
+          <h1 class="__lwc_scope_token__">
+            Scoped style test
+          </h1>
+        </x-scoped-style>
+    `);
+});

--- a/test/src/modules/ssr/scopedStyleHostLight/scopedStyleHostLight.html
+++ b/test/src/modules/ssr/scopedStyleHostLight/scopedStyleHostLight.html
@@ -1,0 +1,9 @@
+<!--
+Copyright (c) 2018, salesforce.com, inc.
+All rights reserved.
+SPDX-License-Identifier: MIT
+For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+-->
+<template lwc:render-mode="light">
+    <h1>Scoped style test</h1>
+</template>

--- a/test/src/modules/ssr/scopedStyleHostLight/scopedStyleHostLight.js
+++ b/test/src/modules/ssr/scopedStyleHostLight/scopedStyleHostLight.js
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { LightningElement } from 'lwc';
+
+export default class ScopedStyleHostLight extends LightningElement {
+    static renderMode = 'light'
+}

--- a/test/src/modules/ssr/scopedStyleHostLight/scopedStyleHostLight.scoped.css
+++ b/test/src/modules/ssr/scopedStyleHostLight/scopedStyleHostLight.scoped.css
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+h1 {
+    color: red;
+}
+
+:host {
+    color: blue;
+}


### PR DESCRIPTION
Another thing missed in #187. We need to sort the regex input so that the full `foo-host` string is replaced.