### PR TITLE
fix: fix serializer errors with elm.attributes

### DIFF
--- a/packages/@lwc/jest-serializer/src/clean-element-attrs.js
+++ b/packages/@lwc/jest-serializer/src/clean-element-attrs.js
@@ -53,8 +53,11 @@ function cleanElementAttributes(elm) {
         elm.removeAttribute(name);
     });
 
-    for (const { name, value } of [...elm.attributes]) {
+    // We've seen cases where elm.attributes is not iterable.
+    // We could do elm.getAttributeNames() here, but we can be a bit extra cautious.
+    for (const name of Element.prototype.getAttributeNames.apply(elm)) {
         if (isKnownScopeToken(name)) {
+            const value = elm.getAttribute(name);
             elm.removeAttribute(name);
             elm.setAttribute('__lwc_scope_token__', value);
         }

--- a/packages/@lwc/jest-shared/src/index.js
+++ b/packages/@lwc/jest-shared/src/index.js
@@ -35,7 +35,7 @@ function addKnownScopeToken(str) {
  */
 function isKnownScopeToken(str) {
     // attributes in the HTML namespace are case-insensitive, so we treat everything as lowercase
-    return knownScopeTokens.has(str.toLowerCase());
+    return typeof str === 'string' && knownScopeTokens.has(str.toLowerCase());
 }
 
 /**

--- a/test/src/modules/serializer/errors/__tests__/__snapshots__/errors.spec.js.snap
+++ b/test/src/modules/serializer/errors/__tests__/__snapshots__/errors.spec.js.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`serializes component that may cause errors in serializer 1`] = `
+<serializer-component>
+  #shadow-root(open)
+    <div />
+</serializer-component>
+`;

--- a/test/src/modules/serializer/errors/__tests__/errors.spec.js
+++ b/test/src/modules/serializer/errors/__tests__/errors.spec.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { createElement } from 'lwc';
+import Errors from '../errors';
+
+it('serializes component that may cause errors in serializer', async () => {
+    const elm = createElement('serializer-component', { is: Errors });
+    document.body.appendChild(elm);
+
+    expect(elm).toMatchSnapshot();
+});

--- a/test/src/modules/serializer/errors/errors.html
+++ b/test/src/modules/serializer/errors/errors.html
@@ -1,0 +1,3 @@
+<template>
+    <div></div>
+</template>

--- a/test/src/modules/serializer/errors/errors.js
+++ b/test/src/modules/serializer/errors/errors.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import { LightningElement, api } from 'lwc';
+
+export default class extends LightningElement {
+    @api
+    get attributes() {
+        const stack = new Error().stack;
+        // Cause an error to be thrown only when called from @lwc/jest-serializer,
+        // so that we don't break unrelated code
+        if (stack.includes('clean-element-attrs.js')) {
+            return undefined;
+        }
+        return [];
+    }
+}

--- a/test/src/modules/serializer/errors2/__tests__/__snapshots__/errors2.spec.js.snap
+++ b/test/src/modules/serializer/errors2/__tests__/__snapshots__/errors2.spec.js.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`serializes component that may cause errors in serializer, part 2 1`] = `
+<serializer-component>
+  #shadow-root(open)
+    <div />
+</serializer-component>
+`;

--- a/test/src/modules/serializer/errors2/__tests__/errors2.spec.js
+++ b/test/src/modules/serializer/errors2/__tests__/errors2.spec.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { createElement } from 'lwc';
+import Errors2 from '../errors2';
+
+it('serializes component that may cause errors in serializer, part 2', async () => {
+    const elm = createElement('serializer-component', { is: Errors2 });
+    document.body.appendChild(elm);
+
+    expect(elm).toMatchSnapshot();
+});

--- a/test/src/modules/serializer/errors2/errors2.html
+++ b/test/src/modules/serializer/errors2/errors2.html
@@ -1,0 +1,3 @@
+<template>
+    <div></div>
+</template>

--- a/test/src/modules/serializer/errors2/errors2.js
+++ b/test/src/modules/serializer/errors2/errors2.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import { LightningElement, api } from 'lwc';
+
+export default class extends LightningElement {
+    @api
+    get attributes() {
+        const stack = new Error().stack;
+        // Cause an error to be thrown only when called from @lwc/jest-serializer,
+        // so that we don't break unrelated code
+        if (stack.includes('clean-element-attrs.js')) {
+            return [
+                { name: null, value: null }
+            ];
+        }
+        return [];
+    }
+}


### PR DESCRIPTION
Fixes some errors we've seen in the wild:

```
Cannot read properties of undefined (reading 'toLowerCase')TypeError: Cannot read properties of undefined (reading 'toLowerCase')
at isKnownScopeToken (node_modules/@lwc/jest-shared/src/index.js:38:37)
```

```
elm.attributes is not iterableTypeError: elm.attributes is not iterable
at cleanElementAttributes (node_modules/@lwc/jest-serializer/src/clean-element-attrs.js:47:16)
```

W-13672056