### PR TITLE
fix: use absolute path to `@lwc/jest-shared`

### DIFF
--- a/packages/@lwc/jest-transformer/src/index.js
+++ b/packages/@lwc/jest-transformer/src/index.js
@@ -122,7 +122,11 @@ module.exports = {
             // the transformer does not run in the same Node process as the serializer.
             const magicString = new MagicString(result.code);
 
-            magicString.append(`\nconst { addKnownScopeToken } = require('@lwc/jest-shared');`);
+            // lwc-test may live in a different directory from the component module code, so
+            // we need to provide an absolute path
+            const jestSharedPath = require.resolve('@lwc/jest-shared');
+
+            magicString.append(`\nconst { addKnownScopeToken } = require(${JSON.stringify(jestSharedPath)});`);
 
             for (const scopeToken of cssScopeTokens) {
                 magicString.append(`\naddKnownScopeToken(${JSON.stringify(scopeToken)});`)


### PR DESCRIPTION
We can't assume that `require('@lwc/jest-shared')` from the component module source will find the package, because it might not be located in an ancestor `node_modules`. On some platforms, the two live in separate directories.

W-13688197