### PR TITLE
fix: configure `enableLwcSpread` compiler option conditionally

### DIFF
--- a/packages/@lwc/jest-transformer/package.json
+++ b/packages/@lwc/jest-transformer/package.json
@@ -30,7 +30,8 @@
         "@babel/preset-typescript": "^7.22.5",
         "@lwc/jest-shared": "12.0.3",
         "babel-preset-jest": "^29.5.0",
-        "magic-string": "^0.30.0"
+        "magic-string": "^0.30.0",
+        "semver": "^7.5.3"
     },
     "peerDependencies": {
         "@lwc/compiler": "^2.48.0",

--- a/packages/@lwc/jest-transformer/src/index.js
+++ b/packages/@lwc/jest-transformer/src/index.js
@@ -6,6 +6,7 @@
  */
 const path = require('path');
 const crypto = require('crypto');
+const semver = require('semver');
 
 const { isKnownScopedCssFile } = require('@lwc/jest-shared');
 
@@ -104,8 +105,13 @@ module.exports = {
                 strictSpecifier: false,
             },
             scopedStyles: isKnownScopedCssFile(filePath),
-            enableLwcSpread: true,
-            enableDynamicComponents: true
+            enableDynamicComponents: true,
+            /**
+             * Prevent causing tons of warning log lines.
+             * @see {@link https://github.com/salesforce/lwc/pull/3544}
+             * @see {@link https://github.com/salesforce/lwc/releases/tag/v2.49.1}
+             */
+            ...(semver.lt(compilerVersion, '2.49.1') ? { enableLwcSpread: true } : {}),
         });
 
         // if is not .js, we add the .compiled extension in the sourcemap


### PR DESCRIPTION
To prevent tons of warning log lines, the LWC compiler option `enableLwcSpread` is now only configured for compiler versions lower than 2.49.1.

The PR that lead to these log lines is https://github.com/salesforce/lwc/pull/3544 ([v2.49.1](https://github.com/salesforce/lwc/releases/tag/v2.49.1)).