### PR TITLE
fix: make snapshots resilient to whitespace changes (BREAKING CHANGE)

### DIFF
--- a/packages/@lwc/jest-serializer/src/clean-element-text-content.js
+++ b/packages/@lwc/jest-serializer/src/clean-element-text-content.js
@@ -1,0 +1,12 @@
+// LWC VFragments use empty text nodes as start/end markers:
+// https://github.com/salesforce/lwc/blob/50c1bfa/packages/%40lwc/engine-core/src/framework/api.ts#L96-L97
+// Removing these from the serialized snapshot reduces whitespace noise in snapshots.
+function cleanElementTextContent(node) {
+    for (const child of [...node.childNodes]) {
+        if (child.nodeType === Node.TEXT_NODE && child.textContent === '') {
+            node.removeChild(child);
+        }
+    }
+}
+
+module.exports = cleanElementTextContent;

--- a/packages/@lwc/jest-serializer/src/index.js
+++ b/packages/@lwc/jest-serializer/src/index.js
@@ -10,6 +10,7 @@ const DOMElement = PrettyFormat.plugins.DOMElement;
 const cleanElementAttributes = require('./clean-element-attrs');
 const cleanElementClasses = require('./clean-element-classes');
 const cleanStyleElement = require('./clean-style-element');
+const cleanElementTextContent = require('./clean-element-text-content');
 
 function test(obj) {
     if (typeof obj !== 'object' || obj === null) {
@@ -55,6 +56,7 @@ function serialize(node, config, indentation, depth, refs, printer) {
     if (isElement) {
         cleanElementAttributes(node);
         cleanElementClasses(node);
+        cleanElementTextContent(node);
         if (node.tagName === 'STYLE') {
             cleanStyleElement(node);
         }

--- a/test/src/modules/serializer/emptyTextNode/__tests__/__snapshots__/emptyTextNode.spec.js.snap
+++ b/test/src/modules/serializer/emptyTextNode/__tests__/__snapshots__/emptyTextNode.spec.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`serializes component with empty text nodes 1`] = `
+<serializer-component>
+  <div>
+    <h1>
+      hello
+    </h1>
+  </div>
+</serializer-component>
+`;

--- a/test/src/modules/serializer/emptyTextNode/__tests__/emptyTextNode.spec.js
+++ b/test/src/modules/serializer/emptyTextNode/__tests__/emptyTextNode.spec.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { createElement } from 'lwc';
+import EmptyTextNode from '../emptyTextNode';
+
+it('serializes component with empty text nodes', () => {
+    const elm = createElement('serializer-component', { is: EmptyTextNode });
+    document.body.appendChild(elm);
+
+    expect(elm).toMatchSnapshot();
+});

--- a/test/src/modules/serializer/emptyTextNode/emptyTextNode.html
+++ b/test/src/modules/serializer/emptyTextNode/emptyTextNode.html
@@ -1,0 +1,3 @@
+<template lwc:render-mode="light">
+    <div lwc:ref="div"></div>
+</template>

--- a/test/src/modules/serializer/emptyTextNode/emptyTextNode.js
+++ b/test/src/modules/serializer/emptyTextNode/emptyTextNode.js
@@ -11,7 +11,7 @@ export default class EmptyTextNode extends LightningElement {
     static renderMode = 'light';
 
     renderedCallback() {
-        const h1 = document.createElement('h1')
+        const h1 = document.createElement('h1');
         h1.textContent = 'hello';
 
         this.refs.div.appendChild(document.createTextNode(''));

--- a/test/src/modules/serializer/emptyTextNode/emptyTextNode.js
+++ b/test/src/modules/serializer/emptyTextNode/emptyTextNode.js
@@ -12,10 +12,10 @@ export default class EmptyTextNode extends LightningElement {
 
     renderedCallback() {
         const h1 = document.createElement('h1')
-        h1.textContent = 'hello'
+        h1.textContent = 'hello';
 
-        this.refs.div.appendChild(document.createTextNode(''))
-        this.refs.div.appendChild(h1)
-        this.refs.div.appendChild(document.createTextNode(''))
+        this.refs.div.appendChild(document.createTextNode(''));
+        this.refs.div.appendChild(h1);
+        this.refs.div.appendChild(document.createTextNode(''));
     }
 }

--- a/test/src/modules/serializer/emptyTextNode/emptyTextNode.js
+++ b/test/src/modules/serializer/emptyTextNode/emptyTextNode.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import { LightningElement } from 'lwc';
+
+export default class EmptyTextNode extends LightningElement {
+    static renderMode = 'light';
+
+    renderedCallback() {
+        const h1 = document.createElement('h1')
+        h1.textContent = 'hello'
+
+        this.refs.div.appendChild(document.createTextNode(''))
+        this.refs.div.appendChild(h1)
+        this.refs.div.appendChild(document.createTextNode(''))
+    }
+}


### PR DESCRIPTION
Breaking change, don't merge until we have the other breaking change in (which would address #198).

This makes snapshots resilient to empty text nodes, which fixes the extra whitespace caused by https://github.com/salesforce/lwc/pull/3308.

W-13831241