### PR TITLE
fix(ssr): do not serialize ZWJ characters

### DIFF
--- a/packages/@lwc/jest-preset/src/ssr/html-serializer.js
+++ b/packages/@lwc/jest-preset/src/ssr/html-serializer.js
@@ -44,6 +44,11 @@ function isVoidElement(name, namespace) {
  * @returns the formatter HTML fragment.
  */
 function formatHTML(src) {
+    // Replace all ZWJ characters _before_ doing any other text processing, because otherwise we will add unnecessary
+    // whitespace and newlines. LWC uses the ZWJ character as a special character to represent empty text nodes.
+    // See: https://github.com/salesforce/lwc/pull/2656
+    src = src.replace(/\u200D/g, '');
+
     let res = '';
     let pos = 0;
     let start = pos;

--- a/test/src/modules/ssr/emptyTextExpression/__tests__/__snapshots__/emptyTextExpression.ssr-test.js.snap
+++ b/test/src/modules/ssr/emptyTextExpression/__tests__/__snapshots__/emptyTextExpression.ssr-test.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders a basic component with an empty text expression 1`] = `
+<ssr-empty-text-expression>
+  <template shadowroot="open">
+    <div>
+    </div>
+  </template>
+</ssr-empty-text-expression>
+`;

--- a/test/src/modules/ssr/emptyTextExpression/__tests__/emptyTextExpression.ssr-test.js
+++ b/test/src/modules/ssr/emptyTextExpression/__tests__/emptyTextExpression.ssr-test.js
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { renderComponent } from 'lwc';
+import EmptyTextExpression from 'ssr/emptyTextExpression';
+
+it('renders a basic component with an empty text expression', () => {
+    const renderedComponent = renderComponent('ssr-empty-text-expression', EmptyTextExpression, {});
+
+    expect(renderedComponent).toMatchSnapshot();
+});

--- a/test/src/modules/ssr/emptyTextExpression/emptyTextExpression.html
+++ b/test/src/modules/ssr/emptyTextExpression/emptyTextExpression.html
@@ -1,0 +1,3 @@
+<template>
+    <div>{empty}</div>
+</template>

--- a/test/src/modules/ssr/emptyTextExpression/emptyTextExpression.js
+++ b/test/src/modules/ssr/emptyTextExpression/emptyTextExpression.js
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    empty = '';
+}

--- a/test/src/modules/ssr/lightDomSlotElement/__tests__/__snapshots__/lightDomSlotElement.ssr-test.js.snap
+++ b/test/src/modules/ssr/lightDomSlotElement/__tests__/__snapshots__/lightDomSlotElement.ssr-test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders a basic component with light DOM slot with element slotted 1`] = `
+<ssr-light-dom-slot-element>
+  <ssr-light-dom-slottable>
+    <div>
+      Hello
+    </div>
+  </ssr-light-dom-slottable>
+</ssr-light-dom-slot-element>
+`;

--- a/test/src/modules/ssr/lightDomSlotElement/__tests__/lightDomSlotElement.ssr-test.js
+++ b/test/src/modules/ssr/lightDomSlotElement/__tests__/lightDomSlotElement.ssr-test.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { renderComponent } from 'lwc';
+import LightDomSlotElement from 'ssr/lightDomSlotElement';
+
+it('renders a basic component with light DOM slot with element slotted', () => {
+    const renderedComponent = renderComponent(
+        'ssr-light-dom-slot-element',
+        LightDomSlotElement,
+        {},
+    );
+
+    expect(renderedComponent).toMatchSnapshot();
+});

--- a/test/src/modules/ssr/lightDomSlotElement/lightDomSlotElement.html
+++ b/test/src/modules/ssr/lightDomSlotElement/lightDomSlotElement.html
@@ -1,0 +1,5 @@
+<template lwc:render-mode="light">
+    <ssr-light-dom-slottable>
+        <div>Hello</div>
+    </ssr-light-dom-slottable>
+</template>

--- a/test/src/modules/ssr/lightDomSlotElement/lightDomSlotElement.js
+++ b/test/src/modules/ssr/lightDomSlotElement/lightDomSlotElement.js
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    static renderMode = 'light';
+}

--- a/test/src/modules/ssr/lightDomSlotEmpty/__tests__/__snapshots__/lightDomSlotEmpty.ssr-test.js.snap
+++ b/test/src/modules/ssr/lightDomSlotEmpty/__tests__/__snapshots__/lightDomSlotEmpty.ssr-test.js.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders a basic component with light DOM slot with nothing slotted 1`] = `
+<ssr-light-dom-slot-empty>
+  <ssr-light-dom-slottable>
+  </ssr-light-dom-slottable>
+</ssr-light-dom-slot-empty>
+`;

--- a/test/src/modules/ssr/lightDomSlotEmpty/__tests__/lightDomSlotEmpty.ssr-test.js
+++ b/test/src/modules/ssr/lightDomSlotEmpty/__tests__/lightDomSlotEmpty.ssr-test.js
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { renderComponent } from 'lwc';
+import LightDomSlotEmpty from 'ssr/lightDomSlotEmpty';
+
+it('renders a basic component with light DOM slot with nothing slotted', () => {
+    const renderedComponent = renderComponent('ssr-light-dom-slot-empty', LightDomSlotEmpty, {});
+
+    expect(renderedComponent).toMatchSnapshot();
+});

--- a/test/src/modules/ssr/lightDomSlotEmpty/lightDomSlotEmpty.html
+++ b/test/src/modules/ssr/lightDomSlotEmpty/lightDomSlotEmpty.html
@@ -1,0 +1,3 @@
+<template lwc:render-mode="light">
+    <ssr-light-dom-slottable></ssr-light-dom-slottable>
+</template>

--- a/test/src/modules/ssr/lightDomSlotEmpty/lightDomSlotEmpty.js
+++ b/test/src/modules/ssr/lightDomSlotEmpty/lightDomSlotEmpty.js
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    static renderMode = 'light';
+}

--- a/test/src/modules/ssr/lightDomSlotText/__tests__/__snapshots__/lightDomSlotText.ssr-test.js.snap
+++ b/test/src/modules/ssr/lightDomSlotText/__tests__/__snapshots__/lightDomSlotText.ssr-test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders a basic component with light DOM slot with text node slotted 1`] = `
+<ssr-light-dom-slot-text>
+  <ssr-light-dom-slottable>
+    Hello
+  </ssr-light-dom-slottable>
+</ssr-light-dom-slot-text>
+`;

--- a/test/src/modules/ssr/lightDomSlotText/__tests__/lightDomSlotText.ssr-test.js
+++ b/test/src/modules/ssr/lightDomSlotText/__tests__/lightDomSlotText.ssr-test.js
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { renderComponent } from 'lwc';
+import LightDomSlotText from 'ssr/lightDomSlotText';
+
+it('renders a basic component with light DOM slot with text node slotted', () => {
+    const renderedComponent = renderComponent('ssr-light-dom-slot-text', LightDomSlotText, {});
+
+    expect(renderedComponent).toMatchSnapshot();
+});

--- a/test/src/modules/ssr/lightDomSlotText/lightDomSlotText.html
+++ b/test/src/modules/ssr/lightDomSlotText/lightDomSlotText.html
@@ -1,0 +1,3 @@
+<template lwc:render-mode="light">
+    <ssr-light-dom-slottable>Hello</ssr-light-dom-slottable>
+</template>

--- a/test/src/modules/ssr/lightDomSlotText/lightDomSlotText.js
+++ b/test/src/modules/ssr/lightDomSlotText/lightDomSlotText.js
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import { LightningElement } from 'lwc';
+
+export default class extends LightningElement {
+    static renderMode = 'light';
+}

--- a/test/src/modules/ssr/lightDomSlottable/lightDomSlottable.html
+++ b/test/src/modules/ssr/lightDomSlottable/lightDomSlottable.html
@@ -1,0 +1,3 @@
+<template lwc:render-mode="light">
+    <slot></slot>
+</template>

--- a/test/src/modules/ssr/lightDomSlottable/lightDomSlottable.js
+++ b/test/src/modules/ssr/lightDomSlottable/lightDomSlottable.js
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import { LightningElement } from 'lwc';
+
+export default class LightDomSlottable extends LightningElement {
+    static renderMode = 'light';
+}


### PR DESCRIPTION
BREAKING CHANGE: snapshots must be updated

Fixes #204

Replaces all ZWJ characters before serializing SSR snapshots. This deals with how empty text nodes are serialized in SSR (see https://github.com/salesforce/lwc/pull/2656).

Some of these tests won't actually have an observable difference until https://github.com/salesforce/lwc/pull/3649 is merged. You'll just have to take my word for it that the snapshots are the same before and after that change. (I tested manually.)