### PR TITLE
fix: improve peerDep for lwc

### DIFF
--- a/packages/@lwc/jest-preset/package.json
+++ b/packages/@lwc/jest-preset/package.json
@@ -22,10 +22,10 @@
         "/src/**/*.js"
     ],
     "peerDependencies": {
-        "@lwc/compiler": "^2.48.0 || ^3.0.0",
-        "@lwc/engine-dom": "^2.48.0 || ^3.0.0",
-        "@lwc/engine-server": "^2.48.0 || ^3.0.0",
-        "@lwc/synthetic-shadow": "^2.48.0 || ^3.0.0",
+        "@lwc/compiler": ">=2.48.0",
+        "@lwc/engine-dom": ">=2.48.0",
+        "@lwc/engine-server": ">=2.48.0",
+        "@lwc/synthetic-shadow": ">=2.48.0",
         "jest": "^26 || ^27 || ^28 || ^29"
     },
     "dependencies": {

--- a/packages/@lwc/jest-transformer/package.json
+++ b/packages/@lwc/jest-transformer/package.json
@@ -34,7 +34,7 @@
         "semver": "^7.5.4"
     },
     "peerDependencies": {
-        "@lwc/compiler": "^2.48.0 || ^3.0.0",
+        "@lwc/compiler": ">=2.48.0",
         "jest": "^26 || ^27 || ^28 || ^29"
     },
     "engines": {


### PR DESCRIPTION
The `>=` format will allow us to avoid needing to change this when lwc v4.0.0 is released.