### PR TITLE
fix: fix error with removing child node

### DIFF
--- a/packages/@lwc/jest-serializer/src/clean-element-text-content.js
+++ b/packages/@lwc/jest-serializer/src/clean-element-text-content.js
@@ -4,7 +4,7 @@
 function cleanElementTextContent(node) {
     for (const child of [...node.childNodes]) {
         if (child.nodeType === Node.TEXT_NODE && child.textContent === '') {
-            node.removeChild(child);
+            child.remove();
         }
     }
 }


### PR DESCRIPTION
In `ui-help-components`, for some reason the line

```js
node.removeChild(child)
```

... fails with the error

```js
PrettyFormatPluginError: The node to be removed is not a child of this node.
  NotFoundError: The node to be removed is not a child of this node.
```

I debugged, and the error comes from JSDOM [here](https://github.com/jsdom/jsdom/blob/a39e0ec4ce9a8806692d986a7ed0cd565ec7498a/lib/jsdom/living/nodes/Node-impl.js#L1059-L1064). And it's bizarre, because `child.parentNode === node` and `node.childNodes[0] === child`, so one is definitely a child of the other.

In any case, changing this to `child.remove()` fixes the error. 🤷 