### PR TITLE
fix: aria props should be configurable/enumerable

### DIFF
--- a/packages/@lwc/jest-preset/src/aria-reflection-polyfill.js
+++ b/packages/@lwc/jest-preset/src/aria-reflection-polyfill.js
@@ -67,6 +67,10 @@ for (const prop of ARIA_STRING_PROPS) {
                     this.setAttribute(attribute, value);
                 }
             },
+            // These props in both WebKit and Chromium are configurable/enumerable. This allows overriding
+            // (Try `Object.getOwnPropertyDescriptor(Element.prototype, 'ariaLabel')` in either browser)
+            configurable: true,
+            enumerable: true,
         });
     }
 }

--- a/test/src/modules/smoke/aria/__tests__/aria.spec.js
+++ b/test/src/modules/smoke/aria/__tests__/aria.spec.js
@@ -58,5 +58,11 @@ describe('ARIA string reflection', () => {
             div[prop] = null;
             expect(div.getAttribute(attribute)).toBeNull();
         });
+
+        it(`${prop} is configurable/enumerable`, () => {
+            const descriptor = Object.getOwnPropertyDescriptor(Element.prototype, prop);
+            expect(descriptor.configurable).toBe(true);
+            expect(descriptor.enumerable).toBe(true);
+        });
     }
 });


### PR DESCRIPTION
This was an oversight from #207. In both the [LWC polyfill](https://github.com/salesforce/lwc/blob/44a01efb1ad9210b780c6d7094994ad24652f181/packages/%40lwc/aria-reflection/src/polyfill.ts#L25-L26) and in Safari/Chrome, these props are enumerable/configurable. Without that, you can't override them, which might break other polyfills.