### PR TITLE
chore: transform `import.meta.env.SSR` to `false` within component code

### DIFF
--- a/packages/@lwc/jest-transformer/src/__tests__/import-meta.test.js
+++ b/packages/@lwc/jest-transformer/src/__tests__/import-meta.test.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+const jestTransform = require('../index.js');
+
+// const test = require('./utils/test-transform').test(require('../client-scoped-import'));
+
+// const DEFAULT_FORM_FACTOR = 'Large';
+
+const SOURCE_FILENAME = 'foo.js';
+const IMPORT_META_SRC = `
+import { LightningElement } from 'lwc';
+export default class Foo extends LightningElement {
+    connectedCallback() {
+        if (import.meta.env.SSR) {
+            doSomethingOnTheServer();
+        } else {
+            doSomethingOnTheClient();
+        }
+    }
+}
+`;
+
+describe('jest transform', () => {
+    it('replaces import.meta.env.SSR with false', () => {
+        const { code } = jestTransform.process(IMPORT_META_SRC, SOURCE_FILENAME) ?? {};
+        expect(code).toContain(`if (false) {`);
+    });
+});

--- a/packages/@lwc/jest-transformer/src/index.js
+++ b/packages/@lwc/jest-transformer/src/index.js
@@ -94,6 +94,10 @@ module.exports = {
             src = transformTypeScript(src, filePath);
         }
 
+        // Replace `import.meta.env.SSR` with `false` prior to parsing the
+        // JavaScript inside the LWC compiler.
+        src = src.replace(/\bimport\.meta\.env\.SSR\b/g, 'false');
+
         // Set default module name and namespace value for the namespace because it can't be properly guessed from the path
         const { code, map, cssScopeTokens } = lwcCompiler.transformSync(src, filePath, {
             name: 'test',


### PR DESCRIPTION
The `import.meta.env.SSR` flag is used in component code where the component author needs to vary behavior depending on the execution environment. In production, `import.meta.env.SSR` will be either `true` (if the component is being server-rendered) or `false` (if the component is rendering in the browser).

We do not intend for Jest to be used to test SSR & component hydration. For that reason, `import.meta.env.SSR` should always evaluate to `false` in Jest tests. This PR makes that change.