### PR TITLE
feat: add support for `import.meta` properties @W-14387292

### DIFF
--- a/packages/@lwc/jest-transformer/src/index.js
+++ b/packages/@lwc/jest-transformer/src/index.js
@@ -36,6 +36,7 @@ const clientScopedImport = require('./transforms/client-scoped-import');
 const messageChannelScopedImport = require('./transforms/message-channel-scoped-import');
 const accessCheck = require('./transforms/access-check-scoped-import');
 const siteScopedImport = require('./transforms/site-scoped-import');
+const importMeta = require('./transforms/import-meta');
 
 const BABEL_TS_CONFIG = {
     sourceMaps: 'inline',
@@ -73,6 +74,7 @@ const BABEL_CONFIG = {
         messageChannelScopedImport,
         accessCheck,
         siteScopedImport,
+        importMeta,
     ],
 };
 

--- a/packages/@lwc/jest-transformer/src/transforms/__tests__/import-meta.test.js
+++ b/packages/@lwc/jest-transformer/src/transforms/__tests__/import-meta.test.js
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+const test = require('./utils/test-transform').test(require('../import-meta'));
+
+describe('import.meta properties', () => {
+    test(
+        'does default transformation',
+        `
+        if (import.meta.url.startsWith('/test/')) {}
+        `,
+        `
+        if (process.url.startsWith('/test/')) {}
+        `,
+    );
+
+    test(
+        'does env transformation inside IfStatement',
+        `
+        !import.meta.env.SSR ? doCsr() : doSsr();
+        `,
+        `
+        !/true/i.test(process.env['SSR']) ? doCsr() : doSsr();
+        `,
+    );
+
+    test(
+        'does env transformation inside ConditionalExpression',
+        `
+        import.meta.env.SSR ? doCsr() : doSsr();
+        `,
+        `
+        /true/i.test(process.env['SSR']) ? doCsr() : doSsr();
+        `,
+    );
+});

--- a/packages/@lwc/jest-transformer/src/transforms/import-meta.js
+++ b/packages/@lwc/jest-transformer/src/transforms/import-meta.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+module.exports = function ({ types: t }) {
+    let currentMemberExpressions = new Set();
+
+    return {
+        visitor: {
+            MemberExpression: {
+                enter(path) {
+                    currentMemberExpressions.add(path);
+                },
+                exit(path) {
+                    currentMemberExpressions.delete(path);
+                },
+            },
+            MetaProperty(path) {
+                // Jest is not able to handle `import.meta` properties , so we need to transform
+                // these into `process.env` equivalents.
+                const { parent } = path;
+                if (
+                    t.isMemberExpression(parent) &&
+                    t.isIdentifier(parent.property) &&
+                    parent.property.name === 'env'
+                ) {
+                    // `import.meta.env.*` properties require some special treatment. Unfortunately
+                    // `process.env` only supports `string` properties, which means that `boolean`
+                    // environmental information e.g. `import.meta.env.SSR` do not work as expected
+                    // out-of-the-box without some extra "massaging".
+                    const envPath = Array.from(currentMemberExpressions.values()).at(-2);
+                    const envName = envPath?.get?.('property.name')?.node;
+                    envPath?.replaceWithSourceString?.(`/true/i.test(process.env['${envName}'])`);
+                } else {
+                    path.replaceWithSourceString('process');
+                }
+            },
+        },
+    };
+};


### PR DESCRIPTION
This PR adds support for `import.meta` properties inside components that are unit tested via Jest. To do so `import.meta.*` properties are rewritten to `process.*`. Special treatment is added for boolean `import.meta.env.*` properties due to the fact that `process.env.*` only allows/supports string properties.