### PR TITLE
fix(jest-transformer): do not replace new.target

### DIFF
--- a/packages/@lwc/jest-transformer/src/transforms/__tests__/import-meta.test.js
+++ b/packages/@lwc/jest-transformer/src/transforms/__tests__/import-meta.test.js
@@ -36,4 +36,18 @@ describe('import.meta properties', () => {
         /true/i.test(process.env['SSR']) ? doCsr() : doSsr();
         `,
     );
+
+    test(
+        'does not transform new.target',
+        `
+        function Foo() {
+          console.log(new.target);
+        }
+        `,
+        `
+        function Foo() {
+          console.log(new.target);
+        }
+        `,
+    );
 });

--- a/packages/@lwc/jest-transformer/src/transforms/import-meta.js
+++ b/packages/@lwc/jest-transformer/src/transforms/import-meta.js
@@ -24,17 +24,23 @@ module.exports = function ({ types: t }) {
                 if (
                     t.isMemberExpression(parent) &&
                     t.isIdentifier(parent.property) &&
-                    parent.property.name === 'env'
+                    path.node.meta.name === 'import' &&
+                    path.node.property.name === 'meta'
                 ) {
-                    // `import.meta.env.*` properties require some special treatment. Unfortunately
-                    // `process.env` only supports `string` properties, which means that `boolean`
-                    // environmental information e.g. `import.meta.env.SSR` do not work as expected
-                    // out-of-the-box without some extra "massaging".
-                    const envPath = Array.from(currentMemberExpressions.values()).at(-2);
-                    const envName = envPath?.get?.('property.name')?.node;
-                    envPath?.replaceWithSourceString?.(`/true/i.test(process.env['${envName}'])`);
-                } else {
-                    path.replaceWithSourceString('process');
+                    if (parent.property.name === 'env') {
+                        // `import.meta.env.*` properties require some special treatment. Unfortunately
+                        // `process.env` only supports `string` properties, which means that `boolean`
+                        // environmental information e.g. `import.meta.env.SSR` do not work as expected
+                        // out-of-the-box without some extra "massaging".
+                        const envPath = Array.from(currentMemberExpressions.values()).at(-2);
+                        const envName = envPath?.get?.('property.name')?.node;
+                        envPath?.replaceWithSourceString?.(
+                            `/true/i.test(process.env['${envName}'])`,
+                        );
+                    } else {
+                        // Transform e.g. `import.meta.url` with `process.url`
+                        path.replaceWithSourceString('process');
+                    }
                 }
             },
         },


### PR DESCRIPTION
Fixes #221.

Instead of replacing every `MetaProperty` with `process`, we check first if it is an `import.meta` meta property. This avoids replacing `new.target`.