### PR TITLE
fix: use jsdom to parse style attr and serialize it

### DIFF
--- a/packages/@lwc/jest-serializer/src/clean-element-styles.js
+++ b/packages/@lwc/jest-serializer/src/clean-element-styles.js
@@ -8,26 +8,16 @@
 function cleanElementStyles(elm) {
     // Normalize trivial whitespace differences (e.g. `style="  foo   bar "` becomes `style="foo bar"`
     // and `style=""` is just removed).
-    const styleAttribute = elm.getAttribute('style') || '';
-    const normalizedStyleAttribute = styleAttribute
-        // Remove leading/trailing space
-        .trim()
-        // Replace multiple space, tab, line break with single space
-        .replace(/\s+/g, ' ')
-        .split(';')
-        .map((_) => `${_.trim()};`)
-        .filter((_) => _ !== ';')
-        // Normalize whitespace around colons, e.g. `color :  red` -> `color: red`
-        .map((declaration) =>
-            declaration
-                .split(':')
-                // remove whitespace before `important`, e.g. `! important` -> `!important`
-                .map((_) => _.trim().replace(/!\simportant/, '!important'))
-                .join(': '),
-        )
-        .join(' ');
-    if (normalizedStyleAttribute) {
-        elm.setAttribute('style', normalizedStyleAttribute);
+    const styles = [];
+    for (let i = 0; i < elm.style.length; i++) {
+        const prop = elm.style[i];
+        const value = elm.style.getPropertyValue(prop);
+        const priority = elm.style.getPropertyPriority(prop);
+        styles.push(`${prop}: ${value}${priority === 'important' ? ' !important' : ''};`);
+    }
+
+    if (styles.length) {
+        elm.setAttribute('style', styles.join(' '));
     } else {
         elm.removeAttribute('style');
     }

--- a/packages/@lwc/jest-serializer/src/clean-element-styles.js
+++ b/packages/@lwc/jest-serializer/src/clean-element-styles.js
@@ -8,13 +8,11 @@
 function cleanElementStyles(elm) {
     // Normalize trivial whitespace differences (e.g. `style="  foo   bar "` becomes `style="foo bar"`
     // and `style=""` is just removed).
-    const styles = [];
-    for (let i = 0; i < elm.style.length; i++) {
-        const prop = elm.style[i];
+    const styles = Array.from(elm.style).map((prop) => {
         const value = elm.style.getPropertyValue(prop);
         const priority = elm.style.getPropertyPriority(prop);
-        styles.push(`${prop}: ${value}${priority === 'important' ? ' !important' : ''};`);
-    }
+        return `${prop}: ${value}${priority === 'important' ? ' !important' : ''};`;
+    });
 
     if (styles.length) {
         elm.setAttribute('style', styles.join(' '));

--- a/test/src/modules/serializer/styleAttr/__tests__/__snapshots__/styleAttr.spec.js.snap
+++ b/test/src/modules/serializer/styleAttr/__tests__/__snapshots__/styleAttr.spec.js.snap
@@ -164,10 +164,14 @@ exports[`serializes component with different whitespace 1`] = `
     <div
       style="background-color: red !important;"
     />
-    <div />
-    <div />
     <div
-      style="text-align: line-break;"
+      style="color: yellow;"
+    />
+    <div
+      style="color: purple;"
+    />
+    <div
+      style="color: purple; text-align: right;"
     />
     <div />
     <div />
@@ -222,10 +226,14 @@ exports[`serializes component with different whitespace 1`] = `
     <div
       style="background-color: red !important;"
     />
-    <div />
-    <div />
     <div
-      style="text-align: line-break;"
+      style="color: yellow;"
+    />
+    <div
+      style="color: purple;"
+    />
+    <div
+      style="color: purple; text-align: right;"
     />
     <div />
     <div />

--- a/test/src/modules/serializer/styleAttr/__tests__/__snapshots__/styleAttr.spec.js.snap
+++ b/test/src/modules/serializer/styleAttr/__tests__/__snapshots__/styleAttr.spec.js.snap
@@ -3,8 +3,7 @@
 exports[`serializes component with different whitespace 1`] = `
 <serializer-component>
   #shadow-root(open)
-    <!-- static style, static opti
-        mized -->
+    <!-- static style, static optimized -->
     <div
       style="color: blue;"
     />
@@ -48,18 +47,21 @@ exports[`serializes component with different whitespace 1`] = `
       style="background-color: red !important;"
     />
     <div
-      style="color: line-break;"
+      style="color: yellow;"
     />
     <div
-      style="color: tab;"
+      style="color: purple;"
     />
     <div
-      style="color: tab; text-align: line-break;"
+      style="color: purple; text-align: right;"
     />
     <div />
     <div />
     <div />
     <div />
+    <div
+      style="background-image: url(data:image/svg+xml;base64,abc123); background-size: 12px;"
+    />
     <!-- static style, not static optimized -->
     <div
       style="color: blue;"
@@ -89,27 +91,34 @@ exports[`serializes component with different whitespace 1`] = `
       style="color: blue; text-align: center;"
     />
     <div
-      style="background-color: red;"
+      style="background-color: red !important;"
     />
     <div
-      style="background-color: red;"
+      style="background-color: red !important;"
     />
     <div
-      style="background-color: red;"
+      style="background-color: red !important;"
     />
     <div
-      style="background-color: red;"
+      style="background-color: red !important;"
     />
+    <div
+      style="background-color: red !important;"
+    />
+    <div />
+    <div
+      style="color: purple;"
+    />
+    <div
+      style="color: purple; text-align: right;"
+    />
+    <div />
     <div />
     <div />
     <div />
     <div
-      style="text-align: line-break;"
+      style="background-image: url(data:image/svg+xml;base64,abc123); background-size: 12px;"
     />
-    <div />
-    <div />
-    <div />
-    <div />
     <!-- dynamic style, static optimized -->
     <div />
     <div />
@@ -155,19 +164,18 @@ exports[`serializes component with different whitespace 1`] = `
     <div
       style="background-color: red !important;"
     />
+    <div />
+    <div />
     <div
-      style="color: line-break;"
-    />
-    <div
-      style="color: tab;"
-    />
-    <div
-      style="color: tab; text-align: line-break;"
+      style="text-align: line-break;"
     />
     <div />
     <div />
     <div
       style="color: blue;"
+    />
+    <div
+      style="background-image: url(data:image/svg+xml;base64,abc123); background-size: 12px;"
     />
     <!-- dynamic style, not static optimized -->
     <div />
@@ -214,19 +222,18 @@ exports[`serializes component with different whitespace 1`] = `
     <div
       style="background-color: red !important;"
     />
+    <div />
+    <div />
     <div
-      style="color: line-break;"
-    />
-    <div
-      style="color: tab;"
-    />
-    <div
-      style="color: tab; text-align: line-break;"
+      style="text-align: line-break;"
     />
     <div />
     <div />
     <div
       style="color: blue;"
+    />
+    <div
+      style="background-image: url(data:image/svg+xml;base64,abc123); background-size: 12px;"
     />
 </serializer-component>
 `;

--- a/test/src/modules/serializer/styleAttr/styleAttr.html
+++ b/test/src/modules/serializer/styleAttr/styleAttr.html
@@ -49,7 +49,7 @@
     <div lwc:spread={undef} style=" ; ; "></div>
     <div lwc:spread={undef} style=""></div>
     <div lwc:spread={undef} style=" "></div>
-    <div style="background-image: url(data:image/svg+xml;base64,abc123); background-size: 12px;"></div>
+    <div lwc:spread={undef} style="background-image: url(data:image/svg+xml;base64,abc123); background-size: 12px;"></div>
 
     <!-- dynamic style, static optimized -->
     <div style={bool}></div>

--- a/test/src/modules/serializer/styleAttr/styleAttr.html
+++ b/test/src/modules/serializer/styleAttr/styleAttr.html
@@ -1,6 +1,5 @@
 <template lwc:preserve-comments>
-    <!-- static style, static opti
-        mized -->
+    <!-- static style, static optimized -->
     <div style="  color: blue  "></div>
     <div style=" color:blue; text-align:center "></div>
     <div style="color:blue;text-align:center "></div>
@@ -9,21 +8,22 @@
     <div style="  color:  blue;   text-align:   center  "></div>
     <div style="  color:  blue;   text-align:   center;  "></div>
     <div style="  color:  blue  ;   text-align:   center  ;"></div>
-    <div style="  ;  color  :  blue  ;   text-align  :   center  ;  ;  "></div>
+    <div style="  color  :  blue  ;   text-align  :   center  ;  ;  "></div>
     <div style="background-color: red !important ;"></div>
     <div style="background-color: red  !important  ;"></div>
     <div style="background-color:  red  !important  ;  "></div>
     <div style="  background-color  :  red  !important  ;  "></div>
-    <div style="  background-color  :  red  !  important  ;  "></div>
+    <div style="  background-color  :  red  !important  ;  "></div>
     <div style="color:
-    line-break"></div>
-    <div style="color:	tab;"></div>
-    <div style="color : 	 tab ; 
-    text-align: line-break;"></div>
+    yellow"></div>
+    <div style="color:	purple;"></div>
+    <div style="color : 	 purple ;
+    text-align: right;"></div>
     <div style=";;"></div>
     <div style=" ; ; "></div>
     <div style=""></div>
     <div style=" "></div>
+    <div style="background-image: url(data:image/svg+xml;base64,abc123); background-size: 12px;"></div>
 
     <!-- static style, not static optimized -->
     <div lwc:spread={undef} style="  color: blue  "></div>
@@ -34,21 +34,22 @@
     <div lwc:spread={undef} style="  color:  blue;   text-align:   center  "></div>
     <div lwc:spread={undef} style="  color:  blue;   text-align:   center;  "></div>
     <div lwc:spread={undef} style="  color:  blue  ;   text-align:   center  ;"></div>
-    <div lwc:spread={undef} style="  ;  color  :  blue  ;   text-align  :   center  ;  ;  "></div>
+    <div lwc:spread={undef} style="  color  :  blue  ;   text-align  :   center  ;  ;  "></div>
     <div lwc:spread={undef} style="background-color: red !important ;"></div>
     <div lwc:spread={undef} style="background-color: red  !important  ;"></div>
     <div lwc:spread={undef} style="background-color:  red  !important  ;  "></div>
     <div lwc:spread={undef} style="  background-color  :  red  !important  ;  "></div>
-    <div lwc:spread={undef} style="  background-color  :  red  !  important  ;  "></div>
+    <div lwc:spread={undef} style="  background-color  :  red  !important  ;  "></div>
     <div lwc:spread={undef} style="color:
-    line-break"></div>
-    <div lwc:spread={undef} style="color:	tab;"></div>
-    <div lwc:spread={undef} style="color : 	 tab ; 
-    text-align: line-break;"></div>
+    yellow"></div>
+    <div lwc:spread={undef} style="color:	purple;"></div>
+    <div lwc:spread={undef} style="color : 	 purple ;
+    text-align: right;"></div>
     <div lwc:spread={undef} style=";;"></div>
     <div lwc:spread={undef} style=" ; ; "></div>
     <div lwc:spread={undef} style=""></div>
     <div lwc:spread={undef} style=" "></div>
+    <div style="background-image: url(data:image/svg+xml;base64,abc123); background-size: 12px;"></div>
 
     <!-- dynamic style, static optimized -->
     <div style={bool}></div>
@@ -75,6 +76,7 @@
     <div style={test17}></div>
     <div style={test18}></div>
     <div style={test19}></div>
+    <div style={test20}></div>
 
     <!-- dynamic style, not static optimized -->
     <div lwc:spread={bool} style={bool}></div>
@@ -101,4 +103,5 @@
     <div lwc:spread={undef} style={test17}></div>
     <div lwc:spread={undef} style={test18}></div>
     <div lwc:spread={undef} style={test19}></div>
+    <div lwc:spread={undef} style={test20}></div>
 </template>

--- a/test/src/modules/serializer/styleAttr/styleAttr.js
+++ b/test/src/modules/serializer/styleAttr/styleAttr.js
@@ -20,16 +20,17 @@ export default class ClassAttr extends LightningElement {
     test5 = '  color:  blue;   text-align:   center  ';
     test6 = '  color:  blue;   text-align:   center;  ';
     test7 = '  color:  blue  ;   text-align:   center  ;';
-    test8 = '  ;  color  :  blue  ;   text-align  :   center  ;  ;  ';
+    test8 = '  color  :  blue  ;   text-align  :   center  ;  ;  ';
     test9 = 'background-color: red !important ;';
     test10 = 'background-color: red  !important  ;';
     test11 = 'background-color:  red  !important  ;  ';
     test12 = '  background-color  :  red  !important  ;  ';
-    test13 = '  background-color  :  red  !  important  ;  ';
+    test13 = '  background-color  :  red  !important  ;  ';
     test14 = 'color: \nline-break';
     test15 = 'color:\ttab;';
     test16 = 'color :\ttab ; \ntext-align: line-break;';
     test17 = ';;';
     test18 = ' ; ; ';
     test19 = '  color: blue  ';
+    test20 = 'background-image: url(data:image/svg+xml;base64,abc123); background-size: 12px;';
 }

--- a/test/src/modules/serializer/styleAttr/styleAttr.js
+++ b/test/src/modules/serializer/styleAttr/styleAttr.js
@@ -26,9 +26,9 @@ export default class ClassAttr extends LightningElement {
     test11 = 'background-color:  red  !important  ;  ';
     test12 = '  background-color  :  red  !important  ;  ';
     test13 = '  background-color  :  red  !important  ;  ';
-    test14 = 'color: \nline-break';
-    test15 = 'color:\ttab;';
-    test16 = 'color :\ttab ; \ntext-align: line-break;';
+    test14 = 'color: \nyellow';
+    test15 = 'color:\tpurple;';
+    test16 = 'color :\tpurple ; \ntext-align: right;';
     test17 = ';;';
     test18 = ' ; ; ';
     test19 = '  color: blue  ';


### PR DESCRIPTION
It occurred to me that, instead of regexes, we can use the `elm.style` CSSStyleDeclaration object to serialize out the `style` attribute. This has some benefits:

1. We delegate the hard work to JSDOM
2. We can handle stuff like `data:` base64 URLs correctly

And some downsides:

1. JSDOM's parsing does not seem perfect, e.g. it doesn't seem to understand `! important` (due to the space) and it doesn't seem to like a leading `;`
2. For invalid CSS declarations (e.g. `color: yolo`) it will just strip them out
3. JSDOM normalizes some values, e.g. `background-color:#FFFFFF;"` becomes `background-color: rgb(255, 255, 255);`

I think this is an acceptable tradeoff, especially since it makes the code a lot cleaner.