### PR TITLE
fix: fix excessive __lwc_scope_token__ replacement

### DIFF
--- a/packages/@lwc/jest-serializer/src/clean-style-element.js
+++ b/packages/@lwc/jest-serializer/src/clean-style-element.js
@@ -5,10 +5,17 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-const { getKnownScopeTokensRegex } = require('@lwc/jest-shared');
+const { getKnownScopeTokensRegex, hasKnownScopeTokens } = require('@lwc/jest-shared');
 
 function cleanStyleElement(elm) {
-    elm.textContent = elm.textContent.replace(getKnownScopeTokensRegex(), '__lwc_scope_token__');
+    // Only do this replacement if we actually know about any scope tokens. Otherwise, the regex will
+    // just be `(?:)` which replaces every character.
+    if (hasKnownScopeTokens) {
+        elm.textContent = elm.textContent.replace(
+            getKnownScopeTokensRegex(),
+            '__lwc_scope_token__',
+        );
+    }
     elm.removeAttribute('data-rendered-by-lwc'); // irrelevant for the snapshot, added by the framework
 }
 

--- a/packages/@lwc/jest-shared/src/index.js
+++ b/packages/@lwc/jest-shared/src/index.js
@@ -39,6 +39,14 @@ function isKnownScopeToken(str) {
 }
 
 /**
+ * Check if there are any scope tokens we know about
+ * @returns {boolean} - true if we have any scope tokens
+ */
+function hasKnownScopeTokens() {
+    return knownScopeTokens.size > 0;
+}
+
+/**
  * Get a regex matching all known scope tokens
  @returns {RegExp} - regex representing the list of known scope tokens
  */
@@ -55,4 +63,5 @@ module.exports = {
     addKnownScopeToken,
     isKnownScopeToken,
     getKnownScopeTokensRegex,
+    hasKnownScopeTokens,
 };


### PR DESCRIPTION
For reasons I don't understand yet, it's possible for us to end up with a serialized DOM like this:

```
__lwc_scope_token__[__lwc_scope_token__p__lwc_scope_token__a__lwc_scope_token__r
__lwc_scope_token__t__lwc_scope_token__=__lwc_scope_token__'__lwc_scope_token__
b__lwc_scope_token__u__lwc_scope_token__t__lwc_scope_token__t__lwc_scope_token__
o__lwc_scope_token__n[...]
```

The proximate cause is this code:

https://github.com/salesforce/lwc-test/blob/c78dca8b39c691c8eb9af1b840e84f076449e55b/packages/%40lwc/jest-serializer/src/clean-style-element.js#L11

The problem is that the regex ends up being `(?:)` because there are no known scope tokens.

I can't figure out how it's possible for us _not_ to have any known scope tokens, but in any case, it's much more catastraphic to over-replace than to just skip the replacement.

So even in the absence of a reproducible test case, I propose we just skip the replacement for now if there are no known scope tokens.