### PR TITLE
Update @salesforce/apex/* imports to return jest.fn()

### DIFF
--- a/packages/@lwc/jest-preset/README.md
+++ b/packages/@lwc/jest-preset/README.md
@@ -110,6 +110,36 @@ Then, create a new test file in `__tests__` that follows the naming convention `
 
 Now you can write and run the Jest tests!
 
+#### @Salesforce/apex/ Method Mocks
+
+Imports of `@Salesforce/apex/*` automatically resolve to `jest.fn()`, these can be optionally overwritten.
+
+```js
+import apexMethod from '@Salesforce/apex/apexClass.apexMethod';
+
+it('test apex cal', async () => {
+    apexMethod.mockResolvedValue({ foo: 'bar' });
+});
+```
+
+Optional set function for method manually
+
+```js
+import apexMethod from '@Salesforce/apex/apexClass.apexMethod';
+
+jest.mock(
+    '@salesforce/apex/apexClass.apexMethod',
+    () => ({
+        default: jest.fn(),
+    }),
+    { virtual: true },
+);
+
+it('test apex callout', async () => {
+    apexMethod.mockResolvedValue({ foo: 'bar' });
+});
+```
+
 ### Custom matchers
 
 This package contains convenience functions to help test web components, including Lightning Web Components.

--- a/packages/@lwc/jest-transformer/src/transforms/__tests__/apex-continuation-scoped-import.test.js
+++ b/packages/@lwc/jest-transformer/src/transforms/__tests__/apex-continuation-scoped-import.test.js
@@ -18,9 +18,7 @@ describe('@salesforce/apexContinuation import', () => {
         try {
           myMethod = require("@salesforce/apexContinuation/FooController.fooMethod").default;
         } catch (e) {
-          global.__lwcJestMock_myMethod = global.__lwcJestMock_myMethod || function myMethod() {
-            return Promise.resolve();
-          };
+          global.__lwcJestMock_myMethod = global.__lwcJestMock_myMethod || jest.fn(Promise.resolve());
 
           myMethod = global.__lwcJestMock_myMethod;
         }
@@ -40,9 +38,7 @@ describe('@salesforce/apexContinuation import', () => {
         try {
           myMethod = require("@salesforce/apexContinuation/FooController.fooMethod").default;
         } catch (e) {
-          global.__lwcJestMock_myMethod = global.__lwcJestMock_myMethod || function myMethod() {
-            return Promise.resolve();
-          };
+          global.__lwcJestMock_myMethod = global.__lwcJestMock_myMethod || jest.fn(Promise.resolve());
 
           myMethod = global.__lwcJestMock_myMethod;
         }

--- a/packages/@lwc/jest-transformer/src/transforms/__tests__/apex-scoped-import.test.js
+++ b/packages/@lwc/jest-transformer/src/transforms/__tests__/apex-scoped-import.test.js
@@ -18,9 +18,7 @@ describe('@salesforce/apex import', () => {
         try {
           myMethod = require("@salesforce/apex/FooController.fooMethod").default;
         } catch (e) {
-          global.__lwcJestMock_myMethod = global.__lwcJestMock_myMethod || function myMethod() {
-            return Promise.resolve();
-          };
+          global.__lwcJestMock_myMethod = global.__lwcJestMock_myMethod || jest.fn(Promise.resolve());
 
           myMethod = global.__lwcJestMock_myMethod;
         }
@@ -40,9 +38,7 @@ describe('@salesforce/apex import', () => {
         try {
           myMethod = require("@salesforce/apex/FooController.fooMethod").default;
         } catch (e) {
-          global.__lwcJestMock_myMethod = global.__lwcJestMock_myMethod || function myMethod() {
-            return Promise.resolve();
-          };
+          global.__lwcJestMock_myMethod = global.__lwcJestMock_myMethod || jest.fn(Promise.resolve());
 
           myMethod = global.__lwcJestMock_myMethod;
         }

--- a/packages/@lwc/jest-transformer/src/transforms/utils.js
+++ b/packages/@lwc/jest-transformer/src/transforms/utils.js
@@ -75,7 +75,7 @@ const resolvedPromiseTemplate = babelTemplate(`
     try {
         RESOURCE_NAME = require(IMPORT_SOURCE).default;
     } catch (e) {
-        global.MOCK_NAME = global.MOCK_NAME || function RESOURCE_NAME() { return Promise.resolve(); };
+        global.MOCK_NAME = global.MOCK_NAME || jest.fn(Promise.resolve());
         RESOURCE_NAME = global.MOCK_NAME;
     }
 `);

--- a/test/src/modules/transformer/apex/__tests__/apex.test.js
+++ b/test/src/modules/transformer/apex/__tests__/apex.test.js
@@ -7,9 +7,13 @@
 import { ApexMethod, refreshApex, getSObjectValue } from '../apex';
 
 describe('@salesforce/apex/<class>', () => {
-    it('exports a default method returning a promise', () => {
-        // expect(ApexMethod()).resolves.toEqual(undefined);
+    it('exports a default method returning a promise', async () => {
         expect(ApexMethod).not.toHaveBeenCalled();
+
+        ApexMethod.mockResolvedValue('bar');
+        const result = await ApexMethod('foo');
+        expect(ApexMethod).toHaveBeenCalledWith('foo');
+        expect(result).toBe('bar');
     });
 });
 

--- a/test/src/modules/transformer/apex/__tests__/apex.test.js
+++ b/test/src/modules/transformer/apex/__tests__/apex.test.js
@@ -8,7 +8,8 @@ import { ApexMethod, refreshApex, getSObjectValue } from '../apex';
 
 describe('@salesforce/apex/<class>', () => {
     it('exports a default method returning a promise', () => {
-        expect(ApexMethod()).resolves.toEqual(undefined);
+        // expect(ApexMethod()).resolves.toEqual(undefined);
+        expect(ApexMethod).not.toHaveBeenCalled();
     });
 });
 
@@ -18,9 +19,9 @@ describe('@salesforce/apex', () => {
     });
 
     it('exports getSObjectValue method returning a jest.fn()', () => {
-        expect(getSObjectValue).not.toBeCalled();
+        expect(getSObjectValue).not.toHaveBeenCalled();
 
         getSObjectValue('foo');
-        expect(getSObjectValue).toBeCalledWith('foo');
+        expect(getSObjectValue).toHaveBeenCalledWith('foo');
     });
 });


### PR DESCRIPTION
After looking for ways to  simplify mocking apex methods in a SFDX project, I found this transformer is applied. However the apex method transforms don't make the imports available within jests. 

This change allows for jests import and use apex methods cleanly without having to mock in each test file. 

This doesn't apply to wired apex methods which would need `createApexTestWireAdapter()`  from [@salesforce/sf](https://github.com/salesforce/sfdx-lwc-jest)

```js
// foo.test.js
import apexMethod from "@salesforce/apex/ApexClass.apexMethod";

describe("c-foo", () => {
  afterEach(() => {
    // resetEnvironment();
  });
  
  
  it("Test mock", async () => {
     apexMethod.mockResolvedValue('value');
  }
}
```

Otherwise any apex method requires

```js 
jest.mock(
  "@salesforce/apex/ApexClass.apexMethod",
  () => {
    return {
      default: jest.fn()
    };
  },
  { virtual: true }
);
```