### PR TITLE
test: ignore expected console error and improve test

### DIFF
--- a/test/src/modules/serializer/styleAttr/__tests__/styleAttr.spec.js
+++ b/test/src/modules/serializer/styleAttr/__tests__/styleAttr.spec.js
@@ -7,6 +7,19 @@
 import { createElement } from 'lwc';
 import StyleAttr from '../styleAttr';
 
+// There is an expected warning message we can ignore
+beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation((message) => {
+        if (!message.includes("Invalid 'style' attribute passed to <div>")) {
+            throw new Error('Unexpected console error message: ' + message);
+        }
+    });
+});
+
+afterEach(() => {
+    jest.restoreAllMocks();
+});
+
 it('serializes component with different whitespace', () => {
     const elm = createElement('serializer-component', { is: StyleAttr });
     document.body.appendChild(elm);

--- a/test/src/modules/transformer/apex/__tests__/apex.test.js
+++ b/test/src/modules/transformer/apex/__tests__/apex.test.js
@@ -14,8 +14,7 @@ describe('@salesforce/apex/<class>', () => {
 
 describe('@salesforce/apex', () => {
     it('exports refreshApex method returning a promise', () => {
-        expect(refreshApex()).not.toBeUndefined();
-        expect(refreshApex().then).toEqual(expect.any(Function)); // should be a thenable (promise)
+        expect(refreshApex()).toBeInstanceOf(Promise);
         expect(refreshApex()).resolves.toEqual(undefined); // should resolve to undefined
     });
 

--- a/test/src/modules/transformer/apex/__tests__/apex.test.js
+++ b/test/src/modules/transformer/apex/__tests__/apex.test.js
@@ -14,7 +14,9 @@ describe('@salesforce/apex/<class>', () => {
 
 describe('@salesforce/apex', () => {
     it('exports refreshApex method returning a promise', () => {
-        expect(refreshApex()).resolves.toEqual(undefined);
+        expect(refreshApex()).not.toBeUndefined();
+        expect(refreshApex().then).toEqual(expect.any(Function)); // should be a thenable (promise)
+        expect(refreshApex()).resolves.toEqual(undefined); // should resolve to undefined
     });
 
     it('exports getSObjectValue method returning a jest.fn()', () => {


### PR DESCRIPTION
This removes an annoying error message in the test (which is totally expected) and also improves the tests for apex methods returning a promise.