### PR TITLE
chore: trim framework-supplied attributes in CSR

### DIFF
--- a/packages/@lwc/jest-serializer/src/clean-element-attrs.js
+++ b/packages/@lwc/jest-serializer/src/clean-element-attrs.js
@@ -8,6 +8,7 @@ const { isKnownScopeToken } = require('@lwc/jest-shared');
 
 const ATTRS_TO_REMOVE = [
     'lwc:host', // https://github.com/salesforce/lwc/pull/1600
+    'data-lwc-host-mutated', // https://github.com/salesforce/lwc/pull/4358
 ];
 
 function cleanElementAttributes(elm) {

--- a/test/src/modules/serializer/frameworkAttrs/__tests__/__snapshots__/frameworkAttrs.spec.js.snap
+++ b/test/src/modules/serializer/frameworkAttrs/__tests__/__snapshots__/frameworkAttrs.spec.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`serializes a component containing framework-supplied attributes 1`] = `
+<serializer-component>
+  <h1>
+    Hello world
+  </h1>
+</serializer-component>
+`;

--- a/test/src/modules/serializer/frameworkAttrs/__tests__/frameworkAttrs.spec.js
+++ b/test/src/modules/serializer/frameworkAttrs/__tests__/frameworkAttrs.spec.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { createElement } from 'lwc';
+import FrameworkAttrs from '../frameworkAttrs';
+
+it('serializes a component containing framework-supplied attributes', () => {
+    const elm = createElement('serializer-component', { is: FrameworkAttrs });
+    document.body.appendChild(elm);
+
+    expect(elm).toMatchSnapshot();
+});

--- a/test/src/modules/serializer/frameworkAttrs/frameworkAttrs.css
+++ b/test/src/modules/serializer/frameworkAttrs/frameworkAttrs.css
@@ -1,0 +1,3 @@
+h1 {
+    color: blue;
+}

--- a/test/src/modules/serializer/frameworkAttrs/frameworkAttrs.html
+++ b/test/src/modules/serializer/frameworkAttrs/frameworkAttrs.html
@@ -1,0 +1,3 @@
+<template lwc:render-mode="light">
+  <h1>Hello world</h1>
+</template>

--- a/test/src/modules/serializer/frameworkAttrs/frameworkAttrs.js
+++ b/test/src/modules/serializer/frameworkAttrs/frameworkAttrs.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import { LightningElement } from 'lwc';
+
+export default class FrameworkAttrs extends LightningElement {
+    static renderMode = 'light';
+
+    connectedCallback() {
+        // Typically this is only added by the framework itself, but here we are explicitly adding it
+        // to make the test simpler
+        this.setAttribute('data-lwc-host-mutated', '');
+    }
+}


### PR DESCRIPTION
Follow-up to #278. I realized we should do this for CSR as well as SSR (even though I can't think of a case where this attribute would be added in pure CSR).