### PR TITLE
fix(snapshots): ignore `data-lwc-host-scope-token`

### DIFF
--- a/packages/@lwc/jest-preset/src/ssr/html-serializer.js
+++ b/packages/@lwc/jest-preset/src/ssr/html-serializer.js
@@ -108,6 +108,7 @@ function formatHTML(src) {
             // `data-lwc-host-mutated` may or may not have an attribute value depending on the version of LWC.
             // See: https://github.com/salesforce/lwc/pull/4385
             .replace(/ data-lwc-host-mutated(="[^"]*")?/g, '')
+            .replace(/ data-lwc-host-scope-token(="[^"]*")?/g, '')
             .replace(/ data-rendered-by-lwc/g, '')
     );
 }

--- a/packages/@lwc/jest-serializer/src/clean-element-attrs.js
+++ b/packages/@lwc/jest-serializer/src/clean-element-attrs.js
@@ -9,6 +9,7 @@ const { isKnownScopeToken } = require('@lwc/jest-shared');
 const ATTRS_TO_REMOVE = [
     'lwc:host', // https://github.com/salesforce/lwc/pull/1600
     'data-lwc-host-mutated', // https://github.com/salesforce/lwc/pull/4358
+    'data-lwc-host-scope-token', // https://github.com/salesforce/lwc/pull/4865
 ];
 
 function cleanElementAttributes(elm) {

--- a/test/src/modules/serializer/frameworkAttrsWithValue/frameworkAttrsWithValue.js
+++ b/test/src/modules/serializer/frameworkAttrsWithValue/frameworkAttrsWithValue.js
@@ -14,5 +14,6 @@ export default class FrameworkAttrsWithValue extends LightningElement {
         // Typically this is only added by the framework itself, but here we are explicitly adding it
         // to make the test simpler
         this.setAttribute('data-lwc-host-mutated', 'class data-foo');
+        this.setAttribute('data-lwc-host-scope-token', 'foo');
     }
 }

--- a/test/src/modules/ssr/frameworkAttrsWithValue/frameworkAttrsWithValue.js
+++ b/test/src/modules/ssr/frameworkAttrsWithValue/frameworkAttrsWithValue.js
@@ -14,5 +14,6 @@ export default class FrameworkAttrsWithValue extends LightningElement {
         // Typically this is only added by the framework itself, but here we are explicitly adding it
         // to make the test simpler
         this.setAttribute('data-lwc-host-mutated', 'class data-foo');
+        this.setAttribute('data-lwc-host-scope-token', 'foo');
     }
 }


### PR DESCRIPTION
We recently added a new framework-specific HTML attribute in https://github.com/salesforce/lwc/pull/4865. This should be ignored by the Jest snapshotter so that it doesn't pollute the snapshot output with attributes that component authors don't care about.