### PR TITLE
@lwc/jest-preset: improve the logging experience

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -76,10 +76,10 @@ module.exports = {
         unitTest({ nativeShadow: true }),
         integration({ nativeShadow: false }),
         integration({ nativeShadow: true }),
-        logging({ nativeShadow: true, loggingFormatter: false }),
         logging({ nativeShadow: false, loggingFormatter: false }),
-        logging({ nativeShadow: true, loggingFormatter: true }),
         logging({ nativeShadow: false, loggingFormatter: true }),
+        logging({ nativeShadow: true, loggingFormatter: false }),
+        logging({ nativeShadow: true, loggingFormatter: true }),
         {
             displayName: {
                 name: `integration (ssr)`,

--- a/jest.config.js
+++ b/jest.config.js
@@ -34,6 +34,7 @@ function integration({ nativeShadow }) {
         moduleNameMapper: {
             '^smoke/(.+)$': '<rootDir>/src/modules/smoke/$1/$1',
             '^(components)/(.+)$': '<rootDir>/src/modules/$1/$2/$2',
+            '^(logging)/(.+)$': '<rootDir>/src/modules/$1/$2/$2',
         },
 
         globals: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -40,7 +40,31 @@ function integration({ nativeShadow }) {
         globals: {
             'lwc-jest': {
                 nativeShadow,
-                loggingFormatter: true,
+            },
+        },
+    };
+}
+
+function logging({ nativeShadow, loggingFormatter }) {
+    return {
+        displayName: {
+            name: `logging formatter (${loggingFormatter ? 'enabled' : 'disabled'} feature)(${
+                nativeShadow ? 'native' : 'synthetic'
+            } shadow)`,
+            color: loggingFormatter ? 'yellow' : 'yellowBright',
+        },
+
+        rootDir: '<rootDir>/test',
+        preset: '@lwc/jest-preset',
+        testMatch: ['**/logging/*/__tests__/**/?(*.)(test).js'],
+        moduleNameMapper: {
+            '^(logging)/(.+)$': '<rootDir>/src/modules/$1/$2/$2',
+        },
+
+        globals: {
+            'lwc-jest': {
+                nativeShadow,
+                loggingFormatter,
             },
         },
     };
@@ -52,6 +76,10 @@ module.exports = {
         unitTest({ nativeShadow: true }),
         integration({ nativeShadow: false }),
         integration({ nativeShadow: true }),
+        logging({ nativeShadow: true, loggingFormatter: false }),
+        logging({ nativeShadow: false, loggingFormatter: false }),
+        logging({ nativeShadow: true, loggingFormatter: true }),
+        logging({ nativeShadow: false, loggingFormatter: true }),
         {
             displayName: {
                 name: `integration (ssr)`,

--- a/jest.config.js
+++ b/jest.config.js
@@ -40,6 +40,7 @@ function integration({ nativeShadow }) {
         globals: {
             'lwc-jest': {
                 nativeShadow,
+                loggingFormatter: true,
             },
         },
     };

--- a/packages/@lwc/jest-preset/README.md
+++ b/packages/@lwc/jest-preset/README.md
@@ -55,6 +55,22 @@ By default, this preset is configured to run the tests with synthetic shadow DOM
 }
 ```
 
+##### loggingFormatter (default=false)
+
+LWC profixies any objects passed as an attribute, in events, etc...
+Meaning when we use the [Console api](https://developer.mozilla.org/en-US/docs/Web/API/console), any LWC profixied objects will appear as empty.
+You could enable this feature to display gracefully:
+
+```json
+{
+    "globals": {
+        "lwc-jest": {
+            "loggingFormatter": true
+        }
+    }
+}
+```
+
 #### LWC components rendered on the Server
 
 Add the `@lwc/jest-preset/ssr` preset to the Jest configuration like so:

--- a/packages/@lwc/jest-preset/src/console.js
+++ b/packages/@lwc/jest-preset/src/console.js
@@ -1,0 +1,16 @@
+const { unwrap } = require('@lwc/engine-dom');
+
+const originalConsole = global.console;
+const augmentedConsole = {
+    ...global.console,
+};
+
+['log', 'info', 'err', 'dir', 'warn', 'debug'].forEach((methodName) => {
+    augmentedConsole[methodName] = (...args) => {
+        originalConsole[methodName].apply(originalConsole, [
+            ...Array.from(args).map((obj) => unwrap(obj)),
+        ]);
+    };
+});
+
+global.console = augmentedConsole;

--- a/packages/@lwc/jest-preset/src/console.js
+++ b/packages/@lwc/jest-preset/src/console.js
@@ -7,9 +7,7 @@ const augmentedConsole = {
 
 ['log', 'info', 'err', 'dir', 'warn', 'debug'].forEach((methodName) => {
     augmentedConsole[methodName] = (...args) => {
-        originalConsole[methodName].apply(originalConsole, [
-            ...Array.from(args).map((obj) => unwrap(obj)),
-        ]);
+        originalConsole[methodName](...args.map(unwrap));
     };
 });
 

--- a/packages/@lwc/jest-preset/src/setup.js
+++ b/packages/@lwc/jest-preset/src/setup.js
@@ -2,7 +2,7 @@
 require('./aria-reflection-polyfill');
 
 const config = global['lwc-jest'] || {};
-const { nativeShadow } = config;
+const { nativeShadow, loggingFormatter } = config;
 
 if (!nativeShadow) {
     if (
@@ -16,6 +16,10 @@ if (!nativeShadow) {
         );
     }
     require('@lwc/synthetic-shadow');
+}
+
+if (loggingFormatter) {
+    require('./console');
 }
 
 // Provides temporary backward compatibility for wire-protocol reform: lwc > 1.5.0

--- a/test/src/modules/logging/basic/__tests__/basic.test.js
+++ b/test/src/modules/logging/basic/__tests__/basic.test.js
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { describe, it, test, expect } from '@jest/globals';
+import { createElement } from 'lwc';
+import Basic from 'logging/basic';
+
+describe('@lwc/jest-reset - logging', () => {
+    it('renders the basic component', () => {
+        // Arrange
+        const sut = createElement('x-basic', { is: Basic });
+        sut.arr = ['a', { b: 5 }];
+
+        // Act
+        document.body.appendChild(sut);
+
+        // Assert
+        expect(document.body.querySelector('x-basic')).toBeInstanceOf(HTMLElement);
+    });
+
+    test('the logs should be displayed', () => {
+        // Arrange
+        const sut = createElement('x-basic', { is: Basic });
+        sut.arr = ['a', { b: 5 }];
+
+        // Act
+        document.body.appendChild(sut);
+
+        // Assert
+        expect(document.body.querySelector('x-basic')).toBeInstanceOf(HTMLElement);
+    });
+});

--- a/test/src/modules/logging/basic/basic.html
+++ b/test/src/modules/logging/basic/basic.html
@@ -1,0 +1,9 @@
+<!--
+Copyright (c) 2025, salesforce.com, inc.
+All rights reserved.
+SPDX-License-Identifier: MIT
+For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+-->
+<template>
+    <pre><code>{plainString}</code></pre>
+</template>

--- a/test/src/modules/logging/basic/basic.js
+++ b/test/src/modules/logging/basic/basic.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { LightningElement, api } from 'lwc';
+
+export default class Basic extends LightningElement {
+    _arr = [];
+
+    @api
+    set arr(arr) {
+        console.info('Received arr:', arr);
+        this._arr = arr;
+    }
+
+    get arr() {
+        return this._arr;
+    }
+
+    get plainString() {
+        return JSON.stringify(this.arr);
+    }
+}


### PR DESCRIPTION
Here a repo to explain and illustrate the `why` of this PR: https://github.com/rochejul/lwc-jest-console-issue
The big picture: LWC profixies objects and if we use the Console api, we could have some confusion in Jest's logs.

This PR introduces a new flag to allow "logging formatting" for LWC tests