### PR TITLE
@W-24054461: Scaffolding plugin+preset packages

### DIFF
--- a/packages/@lwc/vitest-plugin/README.md
+++ b/packages/@lwc/vitest-plugin/README.md
@@ -1,0 +1,8 @@
+# @lwc/vitest-plugin
+
+Vite/Vitest plugin that mocks `@salesforce/*` scoped imports for LWC unit tests.
+
+It is the Vitest counterpart to the `@salesforce/*` mocking that `@lwc/jest-transformer`
+performed under Jest. LWC compilation itself is handled separately by `@lwc/rollup-plugin`.
+
+> **Status:** skeleton. The scoped-import mock logic lands in a later story.

--- a/packages/@lwc/vitest-plugin/package.json
+++ b/packages/@lwc/vitest-plugin/package.json
@@ -1,0 +1,31 @@
+{
+    "name": "@lwc/vitest-plugin",
+    "version": "19.6.1",
+    "description": "Vite/Vitest plugin that mocks @salesforce/* scoped imports for LWC unit tests",
+    "homepage": "https://lwc.dev/",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/salesforce/lwc-test.git",
+        "directory": "packages/@lwc/vitest-plugin"
+    },
+    "bugs": {
+        "url": "https://github.com/salesforce/lwc-test/issues"
+    },
+    "license": "MIT",
+    "type": "module",
+    "main": "src/index.js",
+    "keywords": [
+        "vitest",
+        "vite",
+        "lwc"
+    ],
+    "files": [
+        "/src/**/*.js"
+    ],
+    "exports": {
+        ".": "./src/index.js"
+    },
+    "engines": {
+        "node": ">=20"
+    }
+}

--- a/packages/@lwc/vitest-plugin/src/index.js
+++ b/packages/@lwc/vitest-plugin/src/index.js
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+// Vite plugin: mocks `@salesforce/*` scoped imports for LWC unit tests (skeleton).
+export function salesforceScopedImports() {
+    return {
+        name: '@lwc/vitest-plugin:salesforce-scoped-imports',
+        // TODO: resolveId/load the @salesforce/* virtual modules per emit shape
+    };
+}
+
+export default salesforceScopedImports;

--- a/packages/@lwc/vitest-preset/README.md
+++ b/packages/@lwc/vitest-preset/README.md
@@ -1,0 +1,10 @@
+# @lwc/vitest-preset
+
+Vitest preset configuration and setup files to help test Lightning Web Components.
+
+It is the Vitest counterpart to `@lwc/jest-preset`: `lwcVitestConfig()` assembles a
+Vitest configuration (LWC compilation via `@lwc/rollup-plugin`, the `@salesforce/*`
+mock plugin `@lwc/vitest-plugin`, a jsdom environment, snapshot serialization, and
+setup files), and `@lwc/vitest-preset/setup` provides the LWC test setup.
+
+> **Status:** skeleton. The configuration and setup logic land in later stories.

--- a/packages/@lwc/vitest-preset/package.json
+++ b/packages/@lwc/vitest-preset/package.json
@@ -1,0 +1,35 @@
+{
+    "name": "@lwc/vitest-preset",
+    "version": "19.6.1",
+    "description": "Vitest preset configuration and setup to help test LWC",
+    "homepage": "https://lwc.dev/",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/salesforce/lwc-test.git",
+        "directory": "packages/@lwc/vitest-preset"
+    },
+    "bugs": {
+        "url": "https://github.com/salesforce/lwc-test/issues"
+    },
+    "license": "MIT",
+    "type": "module",
+    "main": "src/index.js",
+    "keywords": [
+        "vitest",
+        "vite",
+        "lwc"
+    ],
+    "files": [
+        "/src/**/*.js"
+    ],
+    "exports": {
+        ".": "./src/index.js",
+        "./setup": "./src/setup.js"
+    },
+    "dependencies": {
+        "@lwc/vitest-plugin": "19.6.1"
+    },
+    "engines": {
+        "node": ">=20"
+    }
+}

--- a/packages/@lwc/vitest-preset/src/index.js
+++ b/packages/@lwc/vitest-preset/src/index.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { fileURLToPath } from 'node:url';
+import { salesforceScopedImports } from '@lwc/vitest-plugin';
+
+// Vitest config factory for LWC (skeleton). Call as `lwcVitestConfig(import.meta.url)`.
+export function lwcVitestConfig(importMetaUrl) {
+    const rootDir = fileURLToPath(new URL('.', importMetaUrl));
+    return {
+        root: rootDir,
+        // TODO: add @lwc/rollup-plugin (compile) to plugins
+        plugins: [salesforceScopedImports()],
+        test: {
+            environment: 'jsdom',
+            // TODO: setupFiles, snapshotSerializers, resolve.alias, pool 'forks' + isolate
+        },
+    };
+}
+
+export default lwcVitestConfig;

--- a/packages/@lwc/vitest-preset/src/setup.js
+++ b/packages/@lwc/vitest-preset/src/setup.js
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+// Vitest setup for LWC — port of `@lwc/jest-preset/src/setup.js` (skeleton).
+// Used via `setupFiles: ['@lwc/vitest-preset/setup']`.
+// TODO (order matters): lwcRuntimeFlags -> aria polyfill -> synthetic-shadow ->
+// engine-dom + ENABLE_EXPERIMENTAL_SIGNALS -> expect.extend matchers -> @wire trap.
+export {};


### PR DESCRIPTION
### Summary

Scaffolds the two net-new packages that the LWC Jest→Vitest migration will build on. This is skeleton only — package skeletons that build and publish a stub artifact. No real mocking/config logic yet; that lands in later stories.

### What's in this PR

Two new packages under packages/@lwc/, both at 19.6.1 (Lerna fixed versioning), ESM ("type": "module"), shipping raw src (no build step):

- @lwc/vitest-plugin— Vite/Vitest plugin that will mock@salesforce/*scoped imports for LWC unit tests. Exposes a stubsalesforceScopedImports()plugin factory. This is the Vitest counterpart to the@salesforce/*mocking that@lwc/jest-transformerdid under Jest.

- @lwc/vitest-preset— Vitest preset. Exposes a stublwcVitestConfig(import.meta.url)config factory (".") and a./setupentry (port target for@lwc/jest-preset/src/setup.js). Depends on@lwc/vitest-plugin.