### PR TITLE
@W-23885879 feat(vitest-plugin): Plugin resolve/load mechanism for @salesforce/* imports

### DIFF
--- a/packages/@lwc/vitest-plugin/src/__tests__/scoped-imports-gate.test.mjs
+++ b/packages/@lwc/vitest-plugin/src/__tests__/scoped-imports-gate.test.mjs
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+/*
+ * A2 gate test: plugin claims mocked @salesforce/*+@label/ specifiers, passes through the rest.
+ * Interim node:test (.mjs hides it from Jest + publish glob); run: node --test <this file>.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { salesforceScopedImports, default as defaultExport } from '../index.js';
+
+const VIRTUAL_PREFIX = '\0salesforce:';
+const plugin = salesforceScopedImports();
+
+// One representative specifier per mocked type + the tricky edges.
+const MOCKED = [
+    '@salesforce/accessCheck/record.Account',
+    '@salesforce/apex/MyClass.method',
+    '@salesforce/apexContinuation/x', // subsumed by the '@salesforce/apex' prefix
+    '@salesforce/client/formFactor',
+    '@salesforce/contentAssetUrl/foo',
+    '@salesforce/customPermission/foo',
+    '@salesforce/i18n/lang',
+    '@salesforce/label/c.greeting',
+    '@label/c.greeting', // legacy prefix
+    '@salesforce/messageChannel/foo__c',
+    '@salesforce/resourceUrl/foo',
+    '@salesforce/schema', // exact, no trailing slash
+    '@salesforce/schema/Account.Name',
+    '@salesforce/site/Id',
+    '@salesforce/user/Id',
+    '@salesforce/user/isGuest',
+    '@salesforce/userPermission/foo',
+];
+
+// Must PASS THROUGH — real npm packages or non-mocked @salesforce/* paths.
+const PASSTHROUGH = [
+    '@salesforce/wire-service-jest-util',
+    '@salesforce/pwa-kit-dev',
+    '@salesforce/eslint-plugin-lwc',
+    '@salesforce/user/somethingElse', // only /Id and /isGuest are mocked
+    '@salesforce/label', // bare: the LABEL prefix requires a trailing slash
+    'lwc',
+    './relative-module',
+    'react',
+];
+
+// apex/schema have no trailing slash, so (like Jest's startsWith) they claim siblings too.
+// Intentional Jest-parity — don't tighten these or the runners diverge.
+const LOOSE_PREFIX_CLAIMED = ['@salesforce/apexFoo', '@salesforce/schemaOther'];
+
+test('plugin shape', () => {
+    assert.equal(defaultExport, salesforceScopedImports, 'default export is the factory');
+    assert.equal(plugin.name, '@lwc/vitest-plugin:salesforce-scoped-imports');
+    // Claim the specifier before Vite core resolution / the esbuild optimizer.
+    assert.equal(plugin.enforce, 'pre');
+    assert.equal(typeof plugin.resolveId, 'function');
+    assert.equal(typeof plugin.load, 'function');
+});
+
+test('resolveId claims every mocked specifier as a virtual id', () => {
+    for (const spec of MOCKED) {
+        assert.equal(plugin.resolveId(spec), VIRTUAL_PREFIX + spec, `should claim ${spec}`);
+    }
+});
+
+test('resolveId passes through everything else (the A2 over-claim fix)', () => {
+    for (const spec of PASSTHROUGH) {
+        assert.equal(plugin.resolveId(spec), null, `should NOT claim ${spec}`);
+    }
+});
+
+test('loose apex/schema prefixes claim sibling specifiers by design (mirrors Jest)', () => {
+    for (const spec of LOOSE_PREFIX_CLAIMED) {
+        assert.equal(
+            plugin.resolveId(spec),
+            VIRTUAL_PREFIX + spec,
+            `loose prefix should claim ${spec}`
+        );
+    }
+});
+
+test('load serves claimed virtual ids and ignores everything else', () => {
+    // A claimed id loads to a module (placeholder value until A3–A10 land).
+    const virtualId = VIRTUAL_PREFIX + '@salesforce/label/c.greeting';
+    assert.equal(plugin.load(virtualId), 'export default "@salesforce/label/c.greeting";');
+    // Non-virtual ids are not ours -> null, so other plugins/Vite load them.
+    assert.equal(plugin.load('@salesforce/label/c.greeting'), null);
+    assert.equal(plugin.load('some-real-module'), null);
+    assert.equal(plugin.load('\0other-plugin:foo'), null);
+});

--- a/packages/@lwc/vitest-plugin/src/index.js
+++ b/packages/@lwc/vitest-plugin/src/index.js
@@ -5,11 +5,49 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-// Vite plugin: mocks `@salesforce/*` scoped imports for LWC unit tests (skeleton).
+// Vite plugin: mocks `@salesforce/*` + `@label/` scoped imports for LWC unit tests.
+// Prefixes mirror the wired Jest transforms' import identifiers (jest-transformer/src/transforms/*) — keep in sync.
+const SCOPED_IMPORT_PREFIXES = [
+    '@salesforce/accessCheck/',
+    '@salesforce/apex', // also claims @salesforce/apexContinuation by prefix
+    '@salesforce/client/',
+    '@salesforce/contentAssetUrl/',
+    '@salesforce/customPermission/',
+    '@salesforce/i18n/',
+    '@salesforce/label/',
+    '@label/',
+    '@salesforce/messageChannel/',
+    '@salesforce/resourceUrl/',
+    '@salesforce/schema',
+    '@salesforce/site/',
+    '@salesforce/user/Id',
+    '@salesforce/user/isGuest',
+    '@salesforce/userPermission/',
+];
+
+// Rollup treats ids beginning with '\0' as virtual, so no other plugin loads them from disk.
+const VIRTUAL_PREFIX = '\0salesforce:';
+
+function isMockedSpecifier(source) {
+    return SCOPED_IMPORT_PREFIXES.some((prefix) => source.startsWith(prefix));
+}
+
 export function salesforceScopedImports() {
     return {
         name: '@lwc/vitest-plugin:salesforce-scoped-imports',
-        // TODO: resolveId/load the @salesforce/* virtual modules per emit shape
+        // Claim the specifier before Vite core resolution and before @lwc/rollup-plugin.
+        enforce: 'pre',
+        resolveId(source) {
+            return isMockedSpecifier(source) ? VIRTUAL_PREFIX + source : null;
+        },
+        load(id) {
+            if (!id.startsWith(VIRTUAL_PREFIX)) {
+                return null;
+            }
+            const specifier = id.slice(VIRTUAL_PREFIX.length);
+            // Placeholder default export; per-type value generators land in later stories (A3–A10).
+            return `export default ${JSON.stringify(specifier)};`;
+        },
     };
 }
 

--- a/packages/@lwc/vitest-preset/src/index.js
+++ b/packages/@lwc/vitest-preset/src/index.js
@@ -16,6 +16,13 @@ export function lwcVitestConfig(importMetaUrl) {
         plugins: [salesforceScopedImports()],
         test: {
             environment: 'jsdom',
+            server: {
+                deps: {
+                    // Force @salesforce/*+@label/ through Vite so the mock plugin's hooks run
+                    // (esbuild pre-bundling bypasses them). UNVERIFIED until vitest/vite installed.
+                    inline: [/^@salesforce\//, /^@label\//],
+                },
+            },
             // TODO: setupFiles, snapshotSerializers, resolve.alias, pool 'forks' + isolate
         },
     };


### PR DESCRIPTION
## Summary

Part of the Jest→Vitest migration (story **A2**). Wires `@lwc/vitest-plugin`
to **recognize and claim** LWC's `@salesforce/*` and `@label/` scoped imports
so they can be mocked in Vitest unit tests — the Vitest counterpart to the
Babel transforms in `@lwc/jest-transformer`.

This story delivers the **routing/gate mechanism only**: it claims the correct
specifiers and serves a placeholder module. The real per-type mock values are
deferred to follow-up stories (A3–A10).

## What changed

- **`vitest-plugin/src/index.js`**
  - `SCOPED_IMPORT_PREFIXES` — the set of scoped-import prefixes the plugin owns.
    Mirrors the wired `*_IMPORT_IDENTIFIER` consts in `@lwc/jest-transformer`
    (source of Jest parity).
  - `resolveId` (`enforce: 'pre'`) — claims any specifier matching an owned
    prefix as a virtual `\0salesforce:` module; returns `null` for everything
    else, so real packages (e.g. `@salesforce/wire-service-jest-util`) resolve
    normally.
  - `load` — serves the claimed virtual module (placeholder default export
    until A3–A10 add real values).
- **`vitest-preset/src/index.js`** — adds `server.deps.inline` for
  `@salesforce/*` + `@label/` so these run through Vite's transform pipeline
  instead of esbuild pre-bundling (which would bypass the plugin hooks).
- **`vitest-plugin/src/__tests__/scoped-imports-gate.test.mjs`** — gate test:
  the plugin claims every mocked specifier, passes through everything else, and
  handles edges (apex subsuming apexContinuation, loose apex/schema prefixes,
  the legacy `@label/` prefix, bare `@salesforce/label`).